### PR TITLE
+Indraneel: Voiding observations if changed value for observation is nul...

### DIFF
--- a/api/src/main/java/org/openmrs/module/emrapi/encounter/EncounterObservationServiceHelper.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/encounter/EncounterObservationServiceHelper.java
@@ -93,6 +93,9 @@ public class EncounterObservationServiceHelper {
                 observation.setValueAsString(observationData.getValue().toString());
             }
         }
+        else if(observationData.getGroupMembers().isEmpty()){
+            observation.setVoided(true);
+        }
         if(observationData.getOrderUuid() != null && !observationData.getOrderUuid().isEmpty()){
             observation.setOrder(getOrderByUuid(observationData.getOrderUuid()));
         }

--- a/api/src/test/java/org/openmrs/module/emrapi/encounter/EncounterObservationServiceHelperTest.java
+++ b/api/src/test/java/org/openmrs/module/emrapi/encounter/EncounterObservationServiceHelperTest.java
@@ -171,9 +171,9 @@ public class EncounterObservationServiceHelperTest {
 
         encounterObservationServiceHelper.update(encounter, observations);
 
-        assertEquals(1, encounter.getObs().size());
-        Obs textObservation = encounter.getObs().iterator().next();
-        assertEquals(null, textObservation.getValueText());
+        assertEquals(1, encounter.getAllObs(true).size());
+        Obs textObservation = encounter.getAllObs(true).iterator().next();
+        assertTrue(textObservation.isVoided());
     }
 
     @Test


### PR DESCRIPTION
In case an observation value in an encounter is set back to null, then we void the observation. Respective unit test (shouldHandleNullValueObservationWhileSaving) modified.
