### PR TITLE
EA-1 - Make EmrOrderService non-transactional. Move EmrOrderService to autowired

### DIFF
--- a/api-1.10/src/main/java/org/openmrs/module/emrapi/encounter/EmrOrderServiceImpl_1_10.java
+++ b/api-1.10/src/main/java/org/openmrs/module/emrapi/encounter/EmrOrderServiceImpl_1_10.java
@@ -20,27 +20,25 @@ import org.openmrs.api.EncounterService;
 import org.openmrs.module.emrapi.encounter.domain.EncounterTransaction;
 import org.openmrs.module.emrapi.encounter.mapper.OpenMRSDrugOrderMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-@Transactional
+@Component (value = "emrOrderService")
 @OpenmrsProfile(openmrsVersion = "1.10")
 public class EmrOrderServiceImpl_1_10 implements EmrOrderService {
     private OpenMRSDrugOrderMapper openMRSDrugOrderMapper;
     private EncounterService encounterService;
 
-    public void setOpenMRSDrugOrderMapper(OpenMRSDrugOrderMapper openMRSDrugOrderMapper) {
+    @Autowired
+    public EmrOrderServiceImpl_1_10(OpenMRSDrugOrderMapper openMRSDrugOrderMapper, EncounterService encounterService) {
         this.openMRSDrugOrderMapper = openMRSDrugOrderMapper;
-    }
-
-    public void setEncounterService(EncounterService encounterService) {
         this.encounterService = encounterService;
     }
 
     @Override
-    @Transactional
     public void save(List<EncounterTransaction.DrugOrder> drugOrders, Encounter encounter) {
         for (EncounterTransaction.DrugOrder drugOrder : drugOrders) {
             DrugOrder omrsDrugOrder = openMRSDrugOrderMapper.map(drugOrder, encounter);

--- a/api-1.10/src/main/resources/moduleApplicationContext.xml
+++ b/api-1.10/src/main/resources/moduleApplicationContext.xml
@@ -22,10 +22,4 @@
 
     <bean id="orderMapper" class="org.openmrs.module.emrapi.encounter.mapper.OrderMapper1_10">
     </bean>
-
-    <bean id="emrOrderServiceTarget" class="org.openmrs.module.emrapi.encounter.EmrOrderServiceImpl_1_10">
-        <property name="openMRSDrugOrderMapper" ref="openMRSDrugOrderMapper"/>
-        <property name="encounterService" ref="encounterService"/>
-    </bean>
-
 </beans>

--- a/api-1.10/src/test/java/org/openmrs/module/emrapi/encounter/EmrOrderServiceImpl_1_10Test.java
+++ b/api-1.10/src/test/java/org/openmrs/module/emrapi/encounter/EmrOrderServiceImpl_1_10Test.java
@@ -54,9 +54,7 @@ public class EmrOrderServiceImpl_1_10Test {
 
     @Test
     public void shouldSaveANewDrugOrder() throws ParseException {
-        EmrOrderServiceImpl_1_10 emrOrderService = new EmrOrderServiceImpl_1_10();
-        emrOrderService.setEncounterService(encounterService);
-        emrOrderService.setOpenMRSDrugOrderMapper(openMRSDrugOrderMapper);
+        EmrOrderServiceImpl_1_10 emrOrderService = new EmrOrderServiceImpl_1_10(openMRSDrugOrderMapper, encounterService);
 
         EncounterTransaction.DrugOrder drugOrder = DrugOrderBuilder.sample("drug-uuid", "day");
         DrugOrder mappedDrugOrder = new DrugOrder();

--- a/api/src/main/java/org/openmrs/module/emrapi/encounter/DefaultEmrOrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/encounter/DefaultEmrOrderServiceImpl.java
@@ -18,7 +18,9 @@ import org.openmrs.Encounter;
 import org.openmrs.annotation.OpenmrsProfile;
 import org.openmrs.api.EncounterService;
 import org.openmrs.module.emrapi.encounter.domain.EncounterTransaction;
+import org.springframework.stereotype.Component;
 
+@Component (value = "emrOrderService")
 @OpenmrsProfile(openmrsVersion = "1.9.*")
 public class DefaultEmrOrderServiceImpl implements EmrOrderService {
 

--- a/api/src/main/java/org/openmrs/module/emrapi/encounter/EmrEncounterServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/encounter/EmrEncounterServiceImpl.java
@@ -21,7 +21,6 @@ import org.openmrs.Obs;
 import org.openmrs.Patient;
 import org.openmrs.Provider;
 import org.openmrs.Visit;
-import org.openmrs.annotation.OpenmrsProfile;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.LocationService;
@@ -34,9 +33,6 @@ import org.openmrs.module.emrapi.encounter.domain.EncounterTransaction;
 import org.openmrs.module.emrapi.encounter.exception.EncounterMatcherNotFoundException;
 import org.openmrs.module.emrapi.encounter.matcher.BaseEncounterMatcher;
 import org.openmrs.module.emrapi.encounter.matcher.DefaultEncounterMatcher;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -116,9 +112,7 @@ public class EmrEncounterServiceImpl extends BaseOpenmrsService implements EmrEn
 
         visitService.saveVisit(visit);
 
-        if (emrOrderService != null) {
-            emrOrderService.save(encounterTransaction.getDrugOrders(), encounter);
-        }
+        emrOrderService.save(encounterTransaction.getDrugOrders(), encounter);
 
         return new EncounterTransaction(visit.getUuid(), encounter.getUuid());
     }

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -250,24 +250,6 @@
         <constructor-arg name="emrOrderService" ref="emrOrderService"/>
     </bean>
 
-    <bean name="emrOrderServiceTarget" class="org.openmrs.module.emrapi.encounter.DefaultEmrOrderServiceImpl">
-    </bean>
-
-    <bean id="emrOrderService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
-        <property name="transactionManager">
-            <ref bean="transactionManager"/>
-        </property>
-        <property name="target" ref="emrOrderServiceTarget"/>
-        <property name="preInterceptors">
-            <ref bean="serviceInterceptors"/>
-        </property>
-        <property name="transactionAttributeSource">
-            <ref bean="transactionAttributeSource"/>
-        </property>
-    </bean>
-
-
-
     <bean id="encounterObservationServiceHelper" class="org.openmrs.module.emrapi.encounter.EncounterObservationServiceHelper">
         <constructor-arg name="conceptService" ref="conceptService"/>
         <constructor-arg name="emrApiProperties" ref="emrApiProperties"/>


### PR DESCRIPTION
Based on discussions on earlier pull request (https://github.com/openmrs/openmrs-module-emrapi/pull/24). 

I tried using different bean names, both annotated with @Openmrsprofile annotation. One problem here is that anything marked with the annotation is loaded by Spring even if it is not specified in xml. If it is specified in xml, Spring creates two beans, one wired with dependencies and another without it. Which means, if I use the annotation, I have to make them @Components and @Autowired. 

Right now, I have made EmrOrderService non-transactional. They are autowired and filtered via OpenmrsProfile. It is currently called from another transactional service, so we are fine (atleast for this release). I will also spend some time trying to figure out why the service is slow when transactional beans are autowired. 
