### PR TITLE
Ability to retain sequence of order entry when saving orders via encountertransaction

### DIFF
--- a/api-1.10/src/main/java/org/openmrs/module/emrapi/encounter/EmrOrderServiceImpl_1_10.java
+++ b/api-1.10/src/main/java/org/openmrs/module/emrapi/encounter/EmrOrderServiceImpl_1_10.java
@@ -15,6 +15,7 @@ package org.openmrs.module.emrapi.encounter;
 
 import org.openmrs.DrugOrder;
 import org.openmrs.Encounter;
+import org.openmrs.Order;
 import org.openmrs.annotation.OpenmrsProfile;
 import org.openmrs.api.EncounterService;
 import org.openmrs.module.emrapi.encounter.domain.EncounterTransaction;
@@ -23,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 
 @Service(value = "emrOrderService")
@@ -39,6 +41,7 @@ public class EmrOrderServiceImpl_1_10 implements EmrOrderService {
 
     @Override
     public void save(List<EncounterTransaction.DrugOrder> drugOrders, Encounter encounter) {
+        encounter.setOrders(new LinkedHashSet<Order>(encounter.getOrders()));
         for (EncounterTransaction.DrugOrder drugOrder : drugOrders) {
             DrugOrder omrsDrugOrder = openMRSDrugOrderMapper.map(drugOrder, encounter);
             encounter.addOrder(omrsDrugOrder);

--- a/api-1.10/src/main/java/org/openmrs/module/emrapi/encounter/mapper/OrderMapper1_10.java
+++ b/api-1.10/src/main/java/org/openmrs/module/emrapi/encounter/mapper/OrderMapper1_10.java
@@ -110,6 +110,7 @@ public class OrderMapper1_10 implements OrderMapper {
 
         drugOrder.setVoided(openMRSDrugOrder.getVoided());
         drugOrder.setVoidReason(openMRSDrugOrder.getVoidReason());
+        drugOrder.setOrderNumber(openMRSDrugOrder.getOrderNumber());
 
         return drugOrder;
     }
@@ -125,6 +126,7 @@ public class OrderMapper1_10 implements OrderMapper {
         emrTestOrder.setVoidReason(order.getVoidReason());
         emrTestOrder.setDateCreated(order.getDateCreated());
         emrTestOrder.setDateChanged(order.getDateChanged());
+        emrTestOrder.setOrderNumber(order.getOrderNumber());
         return emrTestOrder;
     }
 

--- a/api-1.10/src/test/java/org/openmrs/module/emrapi/encounter/mapper/DrugOrderMapper1_10Test.java
+++ b/api-1.10/src/test/java/org/openmrs/module/emrapi/encounter/mapper/DrugOrderMapper1_10Test.java
@@ -38,6 +38,7 @@ import org.openmrs.util.LocaleUtility;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.lang.reflect.Field;
 import java.text.ParseException;
 import java.util.Locale;
 
@@ -71,9 +72,9 @@ public class DrugOrderMapper1_10Test {
     }
 
     @Test
-    public void shouldMapNewDrugOrder() throws ParseException {
+    public void shouldMapNewDrugOrder() throws ParseException, NoSuchFieldException, IllegalAccessException {
 
-        DrugOrder openMrsDrugOrder = drugOrder(CareSetting.CareSettingType.OUTPATIENT, 3, "3-0-2", 5, "before meals", "boil in water", null);
+        DrugOrder openMrsDrugOrder = drugOrder(CareSetting.CareSettingType.OUTPATIENT, 3, "3-0-2", 5, "before meals", "boil in water", null, "ORD-100");
         EncounterTransaction.DrugOrder drugOrder = drugOrderMapper110.mapDrugOrder(openMrsDrugOrder);
 
         assertThat(drugOrder.getCareSetting(), is(equalTo(OUT_PATIENT_CARE_SETTING)));
@@ -103,18 +104,19 @@ public class DrugOrderMapper1_10Test {
 
         assertThat(drugOrder.getInstructions(), is(equalTo("before meals")));
         assertThat(drugOrder.getCommentToFulfiller(), is(equalTo("boil in water")));
+        assertThat(drugOrder.getOrderNumber(), is(equalTo("ORD-100")));
     }
 
     @Test
-    public void shouldSetPreviousOrder(){
-        DrugOrder openMrsDrugOrder = drugOrder(CareSetting.CareSettingType.OUTPATIENT, 3, "3-0-2", 5, "before meals", "boil in water", "previousOrderUuid");
+    public void shouldSetPreviousOrder() throws NoSuchFieldException, IllegalAccessException {
+        DrugOrder openMrsDrugOrder = drugOrder(CareSetting.CareSettingType.OUTPATIENT, 3, "3-0-2", 5, "before meals", "boil in water", "previousOrderUuid", "ORD-100");
         EncounterTransaction.DrugOrder drugOrder = drugOrderMapper110.mapDrugOrder(openMrsDrugOrder);
 
         assertThat(drugOrder.getPreviousOrderUuid(), is(equalTo("previousOrderUuid")));
     }
 
     private DrugOrder drugOrder(CareSetting.CareSettingType careSettingType, int daysToStartAfter, String dosingInstructions,
-                                int duration, String instructions, String commentToFulfiller, String previousOrderUuid) {
+                                int duration, String instructions, String commentToFulfiller, String previousOrderUuid, String orderNumber) throws NoSuchFieldException, IllegalAccessException {
         DrugOrder order = new DrugOrder();
         order.setPatient(new Patient());
         order.setCareSetting(new CareSetting(careSettingType.name(), null, CareSetting.CareSettingType.OUTPATIENT));
@@ -160,6 +162,10 @@ public class DrugOrderMapper1_10Test {
 
         order.setInstructions(instructions);
         order.setCommentToFulfiller(commentToFulfiller);
+
+        Field field = Order.class.getDeclaredField("orderNumber");
+        field.setAccessible(true);
+        field.set(order, orderNumber);
 
         if (StringUtils.isNotBlank(previousOrderUuid)) {
             Order previousOrder = new Order();

--- a/api/src/main/java/org/openmrs/module/emrapi/encounter/domain/EncounterTransaction.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/encounter/domain/EncounterTransaction.java
@@ -470,6 +470,7 @@ public class EncounterTransaction {
         private String voidReason;
         private Date dateCreated;
         private Date dateChanged;
+        private String orderNumber;
 
         @JsonIgnore
         public String getConceptUuid() {
@@ -547,6 +548,14 @@ public class EncounterTransaction {
 
         public void setDateChanged(Date dateChanged) {
             this.dateChanged = dateChanged;
+        }
+
+        public void setOrderNumber(String orderNumber) {
+            this.orderNumber = orderNumber;
+        }
+
+        public String getOrderNumber() {
+            return orderNumber;
         }
     }
 
@@ -668,6 +677,7 @@ public class EncounterTransaction {
         private String durationUnits;
         private Boolean voided;
         private String voidReason;
+        private String orderNumber;
 
         public String getUuid() {
             return uuid;
@@ -843,6 +853,14 @@ public class EncounterTransaction {
 
         public String getVoidReason() {
             return voidReason;
+        }
+
+        public String getOrderNumber() {
+            return orderNumber;
+        }
+
+        public void setOrderNumber(String orderNumber) {
+            this.orderNumber = orderNumber;
         }
     }
 


### PR DESCRIPTION
Exposing orderNumber in encounter transaction order contract and using LinkedHasSet for retaining sequence of ordering as per discussion on https://groups.google.com/a/openmrs.org/forum/#!topic/dev/d4khpPmXjpQ
