### PR TITLE
Adding emr.extraPatientIdentifierTypes Global Property

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -123,7 +123,14 @@
             Primary identifier type for looking up patients, generating barcodes, etc
         </description>
     </globalProperty>
-
+    
+    <globalProperty>
+        <property>emr.extraPatientIdentifierTypes</property>
+        <defaultValue></defaultValue>
+        <description>
+            A list of UUIDs indicating extra Patient Identifier Types that should be displayed
+        </description>
+    </globalProperty>
     <globalProperty>
         <property>emr.atFacilityVisitType</property>
         <defaultValue></defaultValue>


### PR DESCRIPTION
This global property wasn't migrated from the PIH/openmrs-module-emr, but is used in the EMRAPI getextraidentifiers method. It's also used in the coreapps patient header to display multiple identifiers.

The discussion is available in the dev forum https://groups.google.com/a/openmrs.org/forum/#!topic/dev/s6M719M6loM