### PR TITLE
EA-76: Ignore DateMapperTest and quit depending on distro.

### DIFF
--- a/api/src/test/java/org/openmrs/module/emrapi/encounter/DateMapperTest.java
+++ b/api/src/test/java/org/openmrs/module/emrapi/encounter/DateMapperTest.java
@@ -1,15 +1,16 @@
 package org.openmrs.module.emrapi.encounter;
 
-
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.junit.Ignore;
+import org.junit.Test;
 
+@Ignore("Fails on Java 7, see https://issues.openmrs.org/browse/EA-76")
 public class DateMapperTest {
 
     @Test

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -56,12 +56,14 @@
             <groupId>org.openmrs.module</groupId>
             <artifactId>webservices.rest-omod</artifactId>
             <scope>provided</scope>
+            <version>${webservicesRestVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.openmrs.module</groupId>
             <artifactId>webservices.rest-omod-common</artifactId>
             <type>test-jar</type>
             <scope>test</scope>
+            <version>${webservicesRestVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.openmrs.test</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,63 +38,61 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <openmrsTestutilsVersion>1.3</openmrsTestutilsVersion>
-        <distro.groupId>org.openmrs.distro</distro.groupId>
-        <distro.artifactId>referenceapplication</distro.artifactId>
-        <distro.version>2.3</distro.version>
+        <reportingVersion>0.9.8.1</reportingVersion>
+        <serialization.xstreamVersion>0.2.10</serialization.xstreamVersion>
+        <calculationVersion>1.1</calculationVersion>
+        <providermanagementVersion>2.3</providermanagementVersion>
+        <metadatamappingVersion>1.0.2</metadatamappingVersion>
+        <metadatasharingVersion>1.1.10</metadatasharingVersion>
+        <allergyapiVersion>1.3</allergyapiVersion>
         <reportingModuleVersion>0.9.6</reportingModuleVersion>
-        <providermanagementModuleVersion>2.3</providermanagementModuleVersion>
+        <providermanagementVersion>2.3</providermanagementVersion>
         <metadatasharingVersion>1.1.9</metadatasharingVersion>
         <eventVersion>2.2.1</eventVersion>
-        <webservicesRestModuleVersion>2.12</webservicesRestModuleVersion>
+        <webservicesRestVersion>2.12</webservicesRestVersion>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>${distro.groupId}</groupId>
-                <artifactId>${distro.artifactId}</artifactId>
-                <version>${distro.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement> 
 
     <dependencies>
         <!-- Begin OpenMRS modules -->
        <dependency>
             <groupId>org.openmrs.module</groupId>
             <artifactId>reporting-api</artifactId>
+            <version>${reportingVersion}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.openmrs.module</groupId>
             <artifactId>serialization.xstream-api</artifactId>
+            <version>${serialization.xstreamVersion}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.openmrs.module</groupId>
             <artifactId>calculation-api</artifactId>
+            <version>${calculationVersion}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.openmrs.module</groupId>
             <artifactId>providermanagement-api</artifactId>
+            <version>${providermanagementVersion}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.openmrs.module</groupId>
             <artifactId>metadatasharing-api</artifactId>
+            <version>${metadatasharingVersion}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.openmrs</groupId>
             <artifactId>event-api</artifactId>
+            <version>${eventVersion}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
This test just fails with Java 7, see
https://issues.openmrs.org/browse/EA-76?focusedCommentId=236199&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-236199
  modified:   api/src/test/java/org/openmrs/module/emrapi/encounter/DateMapperTest.java
No more depency on distro 2.3.
  modified:   omod/pom.xml
  modified:   pom.xml