### PR TITLE
TRUNK-5360: Deprecate condition methods in the emrapi module

### DIFF
--- a/condition-list/src/main/java/org/openmrs/module/emrapi/conditionslist/ConditionService.java
+++ b/condition-list/src/main/java/org/openmrs/module/emrapi/conditionslist/ConditionService.java
@@ -20,6 +20,10 @@ import org.openmrs.Patient;
 import org.openmrs.annotation.Authorized;
 import org.openmrs.api.OpenmrsService;
 
+/**
+ * @deprecated as of 1.25.0, replaced by {@link ConditionService} in the openmrs core platform 2.2.0
+ */
+@Deprecated
 public interface ConditionService extends OpenmrsService {
 	
 	@Authorized({ PrivilegeConstants.EDIT_CONDITIONS })

--- a/condition-list/src/main/java/org/openmrs/module/emrapi/conditionslist/impl/ConditionServiceImpl.java
+++ b/condition-list/src/main/java/org/openmrs/module/emrapi/conditionslist/impl/ConditionServiceImpl.java
@@ -33,6 +33,10 @@ import org.openmrs.module.emrapi.conditionslist.db.ConditionDAO;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
+/**
+ * @deprecated as of 1.25.0, replaced by {@link ConditionServiceImpl} in the openmrs core platform 2.2.0
+ */
+@Deprecated
 public class ConditionServiceImpl extends BaseOpenmrsService implements ConditionService {
 	
 	private ConditionDAO conditionDAO;


### PR DESCRIPTION
#### JIRA TICKET NAME:

TRUNK-5360: Deprecate condition methods in the emrapi module

#### SUMMARY:

Deprecate methods in the condition object that have been implemented in the core module.