### PR TITLE
TRUNK-5343: Add CodedOrFreeTextAnswer constructor to support coreapps-api-2.2 functionality

### DIFF
--- a/api/src/main/java/org/openmrs/module/emrapi/diagnosis/CodedOrFreeTextAnswer.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/diagnosis/CodedOrFreeTextAnswer.java
@@ -94,6 +94,14 @@ public class CodedOrFreeTextAnswer {
         this.nonCodedAnswer = nonCodedAnswer;
     }
 
+    /**
+     * @since 1.25.0
+     */
+    public  CodedOrFreeTextAnswer(Concept codedAnswer, ConceptName specificCodedAnswer, String nonCodedAnswer){
+        this.nonCodedAnswer = nonCodedAnswer;
+        this.codedAnswer = codedAnswer;
+    }
+
     public String toClientString() {
         if (specificCodedAnswer != null) {
             return CONCEPT_NAME_PREFIX + specificCodedAnswer.getId();


### PR DESCRIPTION
## Description of what I changed
The PR adds CodedOrFreeTextAnswer constructor to support `CodedOrFreeTextAnswer(Concept codedAnswer, ConceptName specificCodedAnswer, String nonCodedAnswer)`.
## Issue I worked on
see https://issues.openmrs.org/browse/TRUNK-5343

## Checklist: I completed these to help reviewers :)
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [ ] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.

