### PR TITLE
EA-130: Allowing diagnosis concept searches against source(s) defined through global property

### DIFF
--- a/api/src/main/java/org/openmrs/module/emrapi/EmrApiConstants.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/EmrApiConstants.java
@@ -197,6 +197,8 @@ public class EmrApiConstants {
     
     public static final String GP_VISIT_ASSIGNMENT_HANDLER_ENCOUNTER_TYPE_TO_VISIT_TYPE_MAP = "emrapi.EmrApiVisitAssignmentHandler.encounterTypeToNewVisitTypeMap";
 
+    public static final String EMR_CONCEPT_SOURCES_FOR_DIAGNOSIS_SEARCH =  "emrapi.conceptSourcesForDiagnosisSearch";
+
     public static final ArrayList<String> UNSAFE_PRIVILEGES = new ArrayList<String>(Arrays.asList(
             "Share Metadata",
             "Edit Reports",

--- a/api/src/main/java/org/openmrs/module/emrapi/EmrApiProperties.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/EmrApiProperties.java
@@ -36,9 +36,7 @@ import org.springframework.util.StringUtils;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -188,13 +186,23 @@ public class EmrApiProperties extends ModuleProperties {
 		return new DiagnosisMetadata(conceptService, getEmrApiConceptSource());
 	}
 
+
 	public List<ConceptSource> getConceptSourcesForDiagnosisSearch() {
-		ConceptSource icd10 = conceptService.getConceptSourceByName("ICD-10-WHO");
-		if (icd10 != null) {
-			return Arrays.asList(icd10);
-		} else {
-			return Collections.emptyList();
+		//The results can very well be cached to reduce calls to database.
+		//however the compatibility requirement to core 1.9.9 do not allow this currently
+		String conceptSourcesForDiagnosisSearch =
+				administrationService.getGlobalProperty(EmrApiConstants.EMR_CONCEPT_SOURCES_FOR_DIAGNOSIS_SEARCH);
+		List<ConceptSource> conceptSourceList = new ArrayList<ConceptSource>();
+		if (StringUtils.hasText(conceptSourcesForDiagnosisSearch)) {
+			String[] specifiedSourceNames = conceptSourcesForDiagnosisSearch.split(",");
+			for (String specifiedSourceName : specifiedSourceNames) {
+				ConceptSource aSource = conceptService.getConceptSourceByName(specifiedSourceName);
+				if (aSource != null) {
+					conceptSourceList.add(aSource);
+				}
+			}
 		}
+		return conceptSourceList;
 	}
 
 	public ConceptSource getEmrApiConceptSource() {

--- a/api/src/test/java/org/openmrs/module/emrapi/EmrApiPropertiesTest.java
+++ b/api/src/test/java/org/openmrs/module/emrapi/EmrApiPropertiesTest.java
@@ -7,7 +7,9 @@ import org.mockito.Mock;
 import org.openmrs.ConceptSource;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.api.ConceptService;
+
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -49,14 +51,18 @@ public class EmrApiPropertiesTest {
     
     @Test
     public void getConceptSourcesForDiagnosisSearch_shouldNotReturnNull(){
-        when(conceptService.getConceptSourceByName("ICD-10-WHO")).thenReturn(null);
+        when(administrationService.getGlobalProperty(EmrApiConstants.EMR_CONCEPT_SOURCES_FOR_DIAGNOSIS_SEARCH)).thenReturn("ICD-10-WHO");
+        when(conceptService.getConceptSourceByName(anyString())).thenReturn(null);
         Assert.assertNotNull(emrApiProperties.getConceptSourcesForDiagnosisSearch());
         Assert.assertTrue(emrApiProperties.getConceptSourcesForDiagnosisSearch().size() == 0);
-        
-        when(conceptService.getConceptSourceByName("ICD-10-WHO")).thenReturn(new ConceptSource());
+
+        ConceptSource icd10Source = new ConceptSource();
+        icd10Source.setName("ICD-10-WHO");
+        when(conceptService.getConceptSourceByName(anyString())).thenReturn(icd10Source);
         Assert.assertNotNull(emrApiProperties.getConceptSourcesForDiagnosisSearch());
         Assert.assertTrue(emrApiProperties.getConceptSourcesForDiagnosisSearch().size() > 0);
         
         
     }
+
 }

--- a/omod/src/main/java/org/openmrs/module/emrapi/web/controller/EmrConceptSearchController.java
+++ b/omod/src/main/java/org/openmrs/module/emrapi/web/controller/EmrConceptSearchController.java
@@ -22,6 +22,7 @@ import org.openmrs.ConceptSource;
 import org.openmrs.module.emrapi.EmrApiProperties;
 import org.openmrs.module.emrapi.concept.EmrConceptService;
 import org.openmrs.module.webservices.rest.SimpleObject;
+import org.openmrs.util.LocaleUtility;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,8 +48,8 @@ public class EmrConceptSearchController {
     public Object search(@RequestParam("term") String query, @RequestParam Integer limit) throws Exception {
         Collection<Concept> diagnosisSets = emrApiProperties.getDiagnosisSets();
         List<ConceptSource> conceptSources = emrApiProperties.getConceptSourcesForDiagnosisSearch();
-        Locale locale = Locale.ENGLISH;
-        List<ConceptSearchResult> conceptSearchResults = emrService.conceptSearch(query, locale, null, diagnosisSets, conceptSources, limit);
+        List<ConceptSearchResult> conceptSearchResults =
+                emrService.conceptSearch(query, LocaleUtility.getDefaultLocale(), null, diagnosisSets, conceptSources, limit);
         ConceptSource conceptSource = conceptSources.isEmpty() ? null: conceptSources.get(0);
         return createListResponse(conceptSearchResults, conceptSource);
     }

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -141,6 +141,13 @@
             Specifies the mapping of encounter types to new visit types for more see https://wiki.openmrs.org/x/vgF4Aw
         </description>
     </globalProperty>
+    <globalProperty>
+        <property>emrapi.conceptSourcesForDiagnosisSearch</property>
+        <defaultValue>ICD-10-WHO</defaultValue>
+        <description>
+            Specifies comma separated list of reference term source names to be used for diagnosis and condition search
+        </description>
+    </globalProperty>
 
     <!-- privileges for conditions, see  org.openmrs.module.emrapi.conditionslist.PrivilegeConstants -->
     <privilege>


### PR DESCRIPTION
introduced global propery 'emrapi.conceptSourcesForDiagnosisSearch'. Updated EmrApiProperties.getConceptSourcesForDiagnosisSearch() to read from global property and fetch matching reference term sources. updated test. 