### PR TITLE
Trunk-5342 : Migrating Encounter Diagnosis data to the new encounter_diagnosis table prior platform 2.2.

### DIFF
--- a/api-2.2/pom.xml
+++ b/api-2.2/pom.xml
@@ -54,7 +54,40 @@
             <type>pom</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-api</artifactId>
+            <version>${project.parent.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-api-1.10</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-api-1.11</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-api-1.12</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>reportingcompatibility-api</artifactId>
+            <version>2.0.4</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api-2.2/src/main/java/openmrs/module/emrapi/diagnosis/MigrateDiagnosis.java
+++ b/api-2.2/src/main/java/openmrs/module/emrapi/diagnosis/MigrateDiagnosis.java
@@ -1,0 +1,103 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package openmrs.module.emrapi.diagnosis;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.openmrs.CodedOrFreeText;
+import org.openmrs.ConditionVerificationStatus;
+import org.openmrs.Obs;
+import org.openmrs.Patient;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.emrapi.EmrApiProperties;
+import org.openmrs.module.emrapi.diagnosis.Diagnosis;
+import org.openmrs.module.emrapi.diagnosis.DiagnosisMetadata;
+import org.openmrs.module.emrapi.diagnosis.DiagnosisService;
+import org.openmrs.module.emrapi.diagnosis.DiagnosisServiceImpl;
+import org.openmrs.module.emrapi.visit.EmrVisitService;
+
+/**
+ * Migrates existing Diagnosis from the obs table to the new encounter_diagnosis table by getting all existing diagnosis
+ * using the emrapi DiagnosisService and then saves them using the openmrs api DiagnosisService.
+ */
+public class MigrateDiagnosis {
+	
+	/**
+	 * Creates new Diagnosis using the Diagnosis model from the openmrs-core and saves it using the new DiagnosisService
+	 * @return true if at least one Diagnosis was migrated
+	 */
+	public Boolean migrate(DiagnosisMetadata diagnosisMetadata) {
+		// Flag that identifies whether atleast one Diagnosis was migrated
+		Boolean migratedAtleastOneEncounterDiagosis = false;
+		
+		EmrVisitService emrVisitService = Context.getService(EmrVisitService.class);
+		DiagnosisService oldDiagnosisService = new DiagnosisServiceImpl();
+		((DiagnosisServiceImpl)oldDiagnosisService).setEncounterService(Context.getEncounterService());
+		((DiagnosisServiceImpl)oldDiagnosisService).setObsService(Context.getObsService());
+		((DiagnosisServiceImpl)oldDiagnosisService).setEmrApiProperties(Context.getRegisteredComponent("emrApiProperties", EmrApiProperties.class));
+		
+		org.openmrs.api.DiagnosisService newDiagnosisService = Context.getService(org.openmrs.api.DiagnosisService.class);
+		List<Integer> patientsIds = emrVisitService.getAllPatientsWithDiagnosis(diagnosisMetadata);
+		
+		for (int id : patientsIds) {
+			Patient patient = Context.getPatientService().getPatient(id);
+			List<org.openmrs.Diagnosis> diagnoses = convert(oldDiagnosisService.getDiagnoses(patient, null));
+			
+			for (org.openmrs.Diagnosis diagnosis : diagnoses) {
+				newDiagnosisService.save(diagnosis);
+				migratedAtleastOneEncounterDiagosis = true;
+			}
+		}
+		return migratedAtleastOneEncounterDiagosis;
+	}
+
+	/**
+	 * Converts a list of emrapi diagnosis objects to a list of core diagnosis objects
+	 * @param emrapiDiagnoses list of emrapi diagnosis
+	 * @return a list of core diagnosis objects.
+	 */
+	private List<org.openmrs.Diagnosis> convert(List<Diagnosis> emrapiDiagnoses) {
+		List<org.openmrs.Diagnosis> coreDiagnoses = new ArrayList<org.openmrs.Diagnosis>();
+		
+		for (Diagnosis emrapiDiagnosis : emrapiDiagnoses) {
+			org.openmrs.Diagnosis coreDiagnosis = new org.openmrs.Diagnosis();
+			Obs obs = emrapiDiagnosis.getExistingObs();
+			coreDiagnosis.setEncounter(obs.getEncounter());
+			coreDiagnosis.setPatient((Patient)obs.getPerson());
+			coreDiagnosis.setDiagnosis(new CodedOrFreeText(emrapiDiagnosis.getDiagnosis().getCodedAnswer(),
+					emrapiDiagnosis.getDiagnosis().getSpecificCodedAnswer(), emrapiDiagnosis.getDiagnosis().getNonCodedAnswer()));
+			coreDiagnosis.setCertainty(emrapiDiagnosis.getCertainty() == Diagnosis.Certainty.CONFIRMED ? ConditionVerificationStatus.CONFIRMED : ConditionVerificationStatus.PROVISIONAL);
+			coreDiagnosis.setCreator(obs.getCreator());
+			coreDiagnosis.setDateCreated(obs.getDateCreated());
+			coreDiagnosis.setVoided(obs.getVoided());
+			coreDiagnosis.setRank(1);
+			if (obs.getVoided()) {
+				coreDiagnosis.setVoidedBy(obs.getVoidedBy());
+				coreDiagnosis.setDateVoided(obs.getDateVoided());
+				coreDiagnosis.setVoidReason(obs.getVoidReason());
+			}
+			obs.setVoided(true);
+			if (obs.isObsGrouping()) {
+				List<Obs> affectedObsChildren = new ArrayList<Obs>(obs.getGroupMembers());
+				for (Obs child : affectedObsChildren) {
+					child.setVoided(true);
+					child.setVoidReason("Migrated parent to the new encounter_diagnosis table");
+				}
+				
+			}
+			
+			Context.getObsService().saveObs(obs, "Voided this Obs due to its migration to new encounter_diagnosis table");
+			coreDiagnoses.add(coreDiagnosis);
+
+		}
+		return coreDiagnoses;
+	}
+
+}

--- a/api-2.2/src/test/java/org/openmrs/emrapi/diagnosis/MigrateDiagnosisTest.java
+++ b/api-2.2/src/test/java/org/openmrs/emrapi/diagnosis/MigrateDiagnosisTest.java
@@ -1,0 +1,108 @@
+package org.openmrs.emrapi.diagnosis;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openmrs.Obs;
+import org.openmrs.Patient;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.EncounterService;
+import org.openmrs.api.PatientService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.emrapi.EmrApiProperties;
+import org.openmrs.module.emrapi.diagnosis.Diagnosis;
+import org.openmrs.module.emrapi.diagnosis.DiagnosisMetadata;
+import org.openmrs.module.emrapi.diagnosis.DiagnosisService;
+import org.openmrs.module.emrapi.test.ContextSensitiveMetadataTestUtils;
+import org.openmrs.module.emrapi.test.builder.ObsBuilder;
+import org.openmrs.module.emrapi.visit.EmrVisitService;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import openmrs.module.emrapi.diagnosis.MigrateDiagnosis;
+
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class MigrateDiagnosisTest extends BaseModuleContextSensitiveTest {
+
+	private static final String DIAGNOSIS_DATASET = "DiagnosisDataset.xml";
+
+	@Autowired
+	ConceptService conceptService;
+
+	@Autowired
+	EncounterService encounterService;
+
+	@Autowired
+	EmrVisitService emrVisitService;
+
+	@Autowired
+	DiagnosisService emrapiDiagnosisService;
+
+	@Autowired
+	org.openmrs.api.DiagnosisService diagnosisService;
+
+	@Autowired
+	PatientService patientService;
+
+	@Autowired
+	EmrApiProperties emrApiProperties;
+
+	private DiagnosisMetadata diagnosisMetadata;
+
+	@Before
+	public void setUp() throws Exception {
+		executeDataSet(DIAGNOSIS_DATASET);
+		diagnosisMetadata = ContextSensitiveMetadataTestUtils.setupDiagnosisMetadata(conceptService, emrApiProperties);
+	}
+
+	@Test
+	public void getAllPatientsWithDiagnosis_shouldReturnListOfPatientIdsWithADiagnosis() {
+		diagnosisMetadata.setDiagnosisSetConcept(conceptService.getConcept(159965));
+		List<Integer> patientIds = emrVisitService.getAllPatientsWithDiagnosis(diagnosisMetadata);
+		
+		assertEquals(2, patientIds.size());
+	}
+
+	@Test
+	public void migrate_shouldVoidEmrapiDiagnosisAndCreateAnewCoreDiagnosis() {
+		Patient patient = patientService.getPatient(7);
+		OldDiagnosisBuilder oldDiagnosisBuilder = new OldDiagnosisBuilder(diagnosisMetadata);
+		Obs obs = oldDiagnosisBuilder.buildDiagnosis(patient, "2013-09-10", Diagnosis.Order.SECONDARY, Diagnosis.Certainty.CONFIRMED, "non-coded pain", encounterService.getEncounter(1)).save().get();
+		oldDiagnosisBuilder.buildDiagnosis(patient, "2013-08-10", Diagnosis.Order.PRIMARY, Diagnosis.Certainty.PRESUMED, "non-coded disease", encounterService.getEncounter(1)).save();
+		assertFalse(obs.getVoided());
+		List<Diagnosis> emrapiDiagnoses = emrapiDiagnosisService.getDiagnoses(patient, null);
+		assertEquals(2, emrapiDiagnoses.size());
+		// before migration
+		assertEquals(0, diagnosisService.getDiagnoses(patient, null).size());
+		
+		new MigrateDiagnosis().migrate(diagnosisMetadata);
+		// after migration
+		assertEquals(2, diagnosisService.getDiagnoses(patient, null).size());
+		assertTrue(obs.getVoided());
+		
+	}
+	
+	@Test
+	public void migrate_shouldVoidChildObsOfMigratedDiagnosis() {
+		Patient patient = patientService.getPatient(7);
+		OldDiagnosisBuilder oldDiagnosisBuilder = new OldDiagnosisBuilder(diagnosisMetadata);
+		ObsBuilder builder = oldDiagnosisBuilder.buildDiagnosis(patient, "2013-09-10", Diagnosis.Order.SECONDARY, Diagnosis.Certainty.CONFIRMED, "non-coded pain", encounterService.getEncounter(1)).
+				addMember(Context.getConceptService().getConcept(3), "Some Value");
+		Obs obs = builder.save().get();
+		// Before migration
+		assertEquals(4, obs.getGroupMembers().size());
+		new MigrateDiagnosis().migrate(diagnosisMetadata);
+		// After migration
+		assertEquals(0, obs.getGroupMembers().size());
+		// Include voided
+		assertEquals(4, obs.getGroupMembers(true).size());
+			
+	}
+}

--- a/api-2.2/src/test/java/org/openmrs/emrapi/diagnosis/OldDiagnosisBuilder.java
+++ b/api-2.2/src/test/java/org/openmrs/emrapi/diagnosis/OldDiagnosisBuilder.java
@@ -1,0 +1,36 @@
+package org.openmrs.emrapi.diagnosis;
+
+import org.openmrs.Concept;
+import org.openmrs.Encounter;
+import org.openmrs.Patient;
+import org.openmrs.module.emrapi.diagnosis.Diagnosis;
+import org.openmrs.module.emrapi.diagnosis.DiagnosisMetadata;
+import org.openmrs.module.emrapi.test.builder.ObsBuilder;
+import org.openmrs.module.reporting.common.DateUtil;
+
+public class OldDiagnosisBuilder {
+
+	private DiagnosisMetadata dmd;
+
+	public OldDiagnosisBuilder(DiagnosisMetadata diagnosisMetadata) {
+		this.dmd = diagnosisMetadata;
+	}
+
+	public ObsBuilder buildDiagnosis(Patient patient, String dateYmd, Diagnosis.Order order, Diagnosis.Certainty certainty, Object diagnosis, Encounter encounter) {
+		ObsBuilder builder = new ObsBuilder()
+				.setPerson(patient)
+				.setEncounter(encounter)
+				.setObsDatetime(DateUtil.parseDate(dateYmd, "yyyy-MM-dd"))
+				.setConcept(dmd.getDiagnosisSetConcept())
+				.addMember(dmd.getDiagnosisOrderConcept(), dmd.getConceptFor(order))
+				.addMember(dmd.getDiagnosisCertaintyConcept(), dmd.getConceptFor(certainty));
+		if (diagnosis instanceof Concept) {
+			builder.addMember(dmd.getCodedDiagnosisConcept(), (Concept) diagnosis);
+		} else if (diagnosis instanceof String) {
+			builder.addMember(dmd.getNonCodedDiagnosisConcept(), (String) diagnosis);
+		} else {
+			throw new IllegalArgumentException("Diagnosis value must be a Concept or String");
+		}
+		return builder;
+	}
+}

--- a/api-2.2/src/test/resources/DiagnosisDataset.xml
+++ b/api-2.2/src/test/resources/DiagnosisDataset.xml
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<dataset>
+	<patient patient_id="7" creator="1" date_created="2015-01-01 00:00:00"  voided="false"/>
+	<patient patient_id="8" creator="1" date_created="2015-01-01 00:00:00"  voided="false"/>
+	<patient patient_id="9" creator="1" date_created="2015-01-01 00:00:00"  voided="false"/>
+
+	<concept concept_id="159965" retired="false" datatype_id="4" class_id="10" is_set="true" creator="1" date_created="2010-12-14 02:44:15.0" version="" changed_by="1" date_changed="2016-07-10 02:52:39.0" uuid="159947AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
+	<concept concept_id="159946" retired="false" datatype_id="2" class_id="5" is_set="false" creator="1" date_created="2010-12-04 22:02:33.0" version="" changed_by="1" date_changed="2015-12-13 15:09:46.0" uuid="159946AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
+	<concept concept_id="159394" retired="false" datatype_id="2" class_id="5" is_set="false" creator="1" date_created="2010-08-24 18:54:05.0" version="" changed_by="1" date_changed="2015-11-04 04:45:03.0" uuid="159394AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
+	<concept concept_id="1284" retired="false" datatype_id="2" class_id="5" is_set="false" creator="1" date_created="2005-02-24 12:33:10.0" version="" changed_by="1" date_changed="2016-07-10 02:53:00.0" uuid="1284AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
+	<concept concept_id="159943" retired="false" datatype_id="4" class_id="11" is_set="false" creator="1" date_created="2010-12-04 21:52:08.0" version="" changed_by="1" date_changed="2015-11-04 04:43:31.0" uuid="159943AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
+	<concept concept_id="159393" retired="false" datatype_id="4" class_id="11" is_set="false" creator="1" date_created="2010-08-24 18:49:47.0" version="" changed_by="1" date_changed="2015-11-03 02:37:41.0" uuid="159393AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
+	<concept concept_id="116128" retired="false" datatype_id="4" class_id="4" is_set="false" creator="1" date_created="2007-11-03 00:00:00.0" version="" changed_by="1" date_changed="2015-11-03 02:51:24.0" uuid="116128AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
+
+	<concept_set concept_set_id="38" concept_id="159965" concept_set="1284" sort_weight="1.0" creator="1" date_created="2011-06-09 00:39:52.0" uuid="38AEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"/>
+
+	<concept_name concept_name_id="16603" concept_id="116128" name="MALARIA" locale="en" locale_preferred="true" creator="1" date_created="2007-11-02 19:28:08.0" concept_name_type="FULLY_SPECIFIED" voided="false" voided_by="1" uuid="16603BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"/>
+
+
+	<location location_id="1901" name="Location tagged to visit" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="f1771d8e-bf1f-4dc5-957f-9d40a5eebf08"/>
+	<visit visit_id="1010" patient_id="7" visit_type_id="1" date_started="2013-04-04 00:00:00.0"  location_id="1901" creator="1" date_created="2005-01-01 00:00:00.0" voided="0" uuid="1esd5218-6b78-11e0-93c3-18a905e044dc" />
+	<encounter encounter_id="1" encounter_type="2" patient_id="7" location_id="1901" form_id="1" encounter_datetime="2008-08-01 00:00:00.0" creator="1" date_created="2008-08-18 14:09:05.0" voided="false" uuid="7779d653-393b-4118-9c83-a3715b82d4ac" visit_id="1010"/>
+
+	<obs obs_id="1" person_id="7" concept_id="159965" encounter_id="1" obs_datetime="2018-05-03 17:47:04.0" location_id="3" creator="1" date_created="2018-05-03 17:47:04.0" voided="false" uuid="fe6b0ab0-0764-439f-977c-e61451fbf9fa" status="FINAL"/>
+	<obs obs_id="2" person_id="7" concept_id="159946" encounter_id="1" obs_datetime="2018-05-03 17:47:04.0" location_id="3" obs_group_id="1" value_coded="159943" creator="1" date_created="2018-05-03 17:47:04.0" voided="false" uuid="19198a86-1b06-43ed-899d-ada1817b28e2" status="FINAL"/>
+	<obs obs_id="3" person_id="7" concept_id="159394" encounter_id="1" obs_datetime="2018-05-03 17:47:04.0" location_id="3" obs_group_id="1" value_coded="159393" creator="1" date_created="2018-05-03 17:47:04.0" voided="false" uuid="df4358f3-3070-47b9-bb5c-ff36ed112d51" status="FINAL"/>
+	<obs obs_id="4" person_id="7" concept_id="1284" encounter_id="1" obs_datetime="2018-05-03 17:47:04.0" location_id="3" obs_group_id="1" value_coded="116128" value_coded_name_id="16603" creator="1" date_created="2018-05-03 17:47:04.0" voided="false" uuid="89f02814-2c50-48ae-bca4-4b4709d42486" status="FINAL"/>
+	<obs obs_id="5" person_id="9" concept_id="159965" encounter_id="1" obs_datetime="2018-05-03 17:47:04.0" location_id="3" obs_group_id="1" value_coded="159393" creator="1" date_created="2018-05-03 17:47:04.0" voided="false" uuid="df4358f3-3070-47b9-bb5c-jhvj34Y51" status="FINAL"/>
+</dataset>

--- a/api/src/main/java/org/openmrs/module/emrapi/db/EmrVisitDAO.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/db/EmrVisitDAO.java
@@ -15,5 +15,6 @@ public interface EmrVisitDAO {
    List<Obs> getConfirmedDiagnoses(Visit visit, DiagnosisMetadata diagnosisMetadata);
    
    List<Obs> getConfirmedPrimaryDiagnoses(Visit visit, DiagnosisMetadata diagnosisMetadata);
-   
+
+	List<Integer> getAllPatientsWithDiagnosis(DiagnosisMetadata diagnosisMetadata);
 }

--- a/api/src/main/java/org/openmrs/module/emrapi/db/EmrVisitDAOImpl.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/db/EmrVisitDAOImpl.java
@@ -1,6 +1,7 @@
 package org.openmrs.module.emrapi.db;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -24,6 +25,7 @@ public class EmrVisitDAOImpl implements EmrVisitDAO {
    protected static String PRIMARY_DIAGNOSES_HQL            = "hql/visit_primary_diagnoses.hql";
    protected static String CONFIRMED_DIAGNOSES_HQL          = "hql/visit_confirmed_diagnoses.hql";
    protected static String CONFIRMED_PRIMARY_DIAGNOSES_HQL  = "hql/visit_confirmed_primary_diagnoses.hql";
+   protected static String PATIENTS_DIAGNOSES_HQL           = "hql/patients_diagnoses.hql";
 
    private DbSessionFactory sessionFactory;
 
@@ -99,5 +101,19 @@ public class EmrVisitDAOImpl implements EmrVisitDAO {
       query.setInteger("diagnosisCertaintyConceptId", diagnosisMetadata.getDiagnosisCertaintyConcept().getId());
       query.setInteger("confirmedCertaintyConceptId", diagnosisMetadata.getConceptFor(Diagnosis.Certainty.CONFIRMED).getId());
       return (List<Obs>) query.list();
+   }
+
+   @Override
+   public List<Integer> getAllPatientsWithDiagnosis(DiagnosisMetadata diagnosisMetadata) {
+      String queryString = "";
+      try {
+    	  queryString = IOUtils.toString(getClass().getClassLoader().getResourceAsStream(PATIENTS_DIAGNOSES_HQL));
+      } catch (IOException e) {
+         log.error(RESOURCE_NOT_FOUND, e);
+         return Collections.emptyList();
+      }
+      Query query = sessionFactory.getCurrentSession().createQuery(queryString);
+      query.setInteger("diagnosisSetConceptId", diagnosisMetadata.getDiagnosisSetConcept().getConceptId());
+      return query.list();
    }
 }

--- a/api/src/main/java/org/openmrs/module/emrapi/test/builder/ObsBuilder.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/test/builder/ObsBuilder.java
@@ -16,6 +16,7 @@ package org.openmrs.module.emrapi.test.builder;
 
 import org.openmrs.Concept;
 import org.openmrs.Drug;
+import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.Person;
 import org.openmrs.User;
@@ -121,6 +122,11 @@ public class ObsBuilder {
 
     public ObsBuilder setCreator(User creator){
         obs.setCreator(creator);
+        return this;
+    }
+
+    public ObsBuilder setEncounter(Encounter encounter) {
+        obs.setEncounter(encounter);
         return this;
     }
 }

--- a/api/src/main/java/org/openmrs/module/emrapi/visit/EmrVisitService.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/visit/EmrVisitService.java
@@ -31,4 +31,6 @@ public interface EmrVisitService extends OpenmrsService {
     VisitResponse find(VisitRequest visitRequest);
     
     List<Obs> getDiagnoses(Visit visit, DiagnosisMetadata diagnosisMetadata, Boolean primaryOnly, Boolean confirmedOnly);
+
+    List<Integer> getAllPatientsWithDiagnosis(DiagnosisMetadata diagnosisMetadata);
 }

--- a/api/src/main/java/org/openmrs/module/emrapi/visit/EmrVisitServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/visit/EmrVisitServiceImpl.java
@@ -28,13 +28,13 @@ import org.openmrs.module.emrapi.visit.contract.VisitResponse;
 public class EmrVisitServiceImpl extends BaseOpenmrsService implements EmrVisitService {
     private VisitService visitService;
     private VisitResponseMapper visitResponseMapper;
-    
+
     protected EmrVisitDAO dao;
-    
+
     public EmrVisitDAO getDao() {
       return dao;
     }
-    
+
     public void setDao(EmrVisitDAO dao) {
        this.dao = dao;
     }
@@ -71,4 +71,9 @@ public class EmrVisitServiceImpl extends BaseOpenmrsService implements EmrVisitS
          }
       }
    }
+
+    @Override
+    public List<Integer> getAllPatientsWithDiagnosis(DiagnosisMetadata diagnosisMetadata) {
+        return dao.getAllPatientsWithDiagnosis(diagnosisMetadata);
+    }
 }

--- a/api/src/main/resources/hql/patients_diagnoses.hql
+++ b/api/src/main/resources/hql/patients_diagnoses.hql
@@ -1,0 +1,10 @@
+select
+  distinct patientId
+from
+  Patient p
+where
+    p.voided = 0
+    and p.patientId in(select distinct personId from Obs o
+    where
+        o.concept.conceptId = :diagnosisSetConceptId
+    )

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -10,3 +10,10 @@ emrapi.patientDataDefinition.primaryIdentifier.description = Patient's primary i
 
 emrapi.visitDataDefinition.mostRecentAdmissionRequest.name = Most Recent Admission Request
 emrapi.visitDataDefinition.mostRecentAdmissionRequest.description = Most recent "Admission" disposition for this patient on his/her active visit
+
+emrapi.migrateDiagnosis.migrateDiagnosisLink.name=Migrate Existing Diagnosis Data
+emrapi.migrateDiagnosis.success.name=Successfully Migrated Encounter Diagnosis data
+emrapi.migrateDiagnosis.migration.error.message=Migration failed, you either already did the migration or have no unvoided Diagnosis data in the DB
+emrapi.migrateDiagnosis.operation.warning.message=Migration of Encounter Diagnosis Operation is irreversible and made only ONCE, are sure you want to continue?  
+emrapi.migrateDiagnosis.verify.operation.name=Verify Operation
+emrapi.migrateDiagnosis.migration.unsupportedPlatformVersionError.message=Unsupported Operation, this feature is only supported by platform 2.2.0 or later versions.

--- a/omod/src/main/java/org/openmrs/module/emrapi/extension/html/AdminList.java
+++ b/omod/src/main/java/org/openmrs/module/emrapi/extension/html/AdminList.java
@@ -1,0 +1,35 @@
+package org.openmrs.module.emrapi.extension.html;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openmrs.api.context.Context;
+import org.openmrs.module.Extension;
+import org.openmrs.module.ModuleUtil;
+import org.openmrs.module.web.extension.AdministrationSectionExt;
+import org.openmrs.util.OpenmrsConstants;
+
+public class AdminList extends AdministrationSectionExt {
+		
+	private static final String DIAGNOSIS_MIGRATION_LEAST_SUPPORTED_VERSION = "2.2.0";
+			
+	@Override
+	public Map<String, String> getLinks() {
+		Map<String, String> links = new HashMap<String, String>();
+		
+		if (ModuleUtil.compareVersion(OpenmrsConstants.OPENMRS_VERSION, DIAGNOSIS_MIGRATION_LEAST_SUPPORTED_VERSION) >= 0) {
+			links.put("module/emrapi/encounterDiagnosisMigrationDashboard.form", "emrapi.migrateDiagnosis.migrateDiagnosisLink.name");
+		}
+		return links;
+	}
+
+	@Override
+	public String getTitle() {
+		return "emrapi.title";
+	}
+
+	@Override
+	public Extension.MEDIA_TYPE getMediaType() {
+		return Extension.MEDIA_TYPE.html;
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/emrapi/web/controller/MigrateDiagnosisController.java
+++ b/omod/src/main/java/org/openmrs/module/emrapi/web/controller/MigrateDiagnosisController.java
@@ -1,0 +1,45 @@
+package org.openmrs.module.emrapi.web.controller;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.openmrs.module.ModuleUtil;
+import org.openmrs.module.emrapi.EmrApiProperties;
+import org.openmrs.module.emrapi.diagnosis.DiagnosisMetadata;
+import org.openmrs.util.OpenmrsConstants;
+import org.openmrs.web.WebConstants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import openmrs.module.emrapi.diagnosis.MigrateDiagnosis;
+
+@Controller
+public class MigrateDiagnosisController {
+	
+	@Autowired
+	EmrApiProperties emrApiProps;
+	
+	@RequestMapping(value = "module/emrapi/encounterDiagnosisMigrationDashboard.form", method = RequestMethod.GET)
+	public String getEncounterDiagnosisMigrationView() {
+		return "module/emrapi/encounterDiagnosisMigrationDashboard";
+	}
+	
+	
+	@RequestMapping(value = "module/emrapi/migrateEncounterDiagnosis.form", method = RequestMethod.GET)
+	public String doEncounterDiagnosisMigration(HttpSession session, HttpServletRequest request) {
+		DiagnosisMetadata diagnosisMetadata = emrApiProps.getDiagnosisMetadata();
+		if (ModuleUtil.compareVersion(OpenmrsConstants.OPENMRS_VERSION, "2.2.0") >= 0) {
+			if (new MigrateDiagnosis().migrate(diagnosisMetadata)) {
+				session.setAttribute(WebConstants.OPENMRS_MSG_ATTR, "emrapi.migrateDiagnosis.success.name");
+			} else {
+				session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "emrapi.migrateDiagnosis.migration.error.message");
+			}
+		} else {
+			session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "emrapi.migrateDiagnosis.migration.unsupportedPlatformVersionError.message");
+		}	
+		return "redirect:encounterDiagnosisMigrationDashboard.form";
+	}
+	
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -90,6 +90,12 @@
     </messages>
     <!-- /Internationalization -->
 
+	<!-- Extensions -->
+	<extension>
+		<point>org.openmrs.admin.list</point>
+		<class>${project.parent.groupId}.${project.parent.artifactId}.extension.html.AdminList</class>
+	</extension>
+	
     <globalProperty>
         <property>emr.encounterMatcher</property>
         <defaultValue></defaultValue>

--- a/omod/src/main/webapp/encounterDiagnosisMigrationDashboard.jsp
+++ b/omod/src/main/webapp/encounterDiagnosisMigrationDashboard.jsp
@@ -1,0 +1,28 @@
+<%@ include file="/WEB-INF/template/include.jsp"%>
+<%@ include file="/WEB-INF/template/header.jsp"%>
+
+<ul id="menu">
+	<li class="first">
+		<a href="${pageContext.request.contextPath}/admin"><spring:message code="admin.title.short"/></a>
+	</li>
+</ul>
+
+<h2>
+	<spring:message code="emrapi.migrateDiagnosis.migrateDiagnosisLink.name"/>
+</h2>
+
+<fieldset>
+	<legend><spring:message code="emrapi.migrateDiagnosis.verify.operation.name"/></legend>
+	<br>
+	<b><spring:message code="emrapi.migrateDiagnosis.operation.warning.message"/></b>
+	<br><br>
+	<table>
+		<tr>
+			<td><input type="button" value="Continue" onclick="document.location.href='migrate.form';"></td>
+			<td><input type="button" value="Cancel" onclick="document.location.href='${pageContext.request.contextPath}/admin';"></td>
+		</tr>
+	</table>
+	
+</fieldset>
+
+<%@ include file="/WEB-INF/template/footer.jsp"%>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <openmrsTestutilsVersion>1.3</openmrsTestutilsVersion>
         <reportingVersion>0.10.4</reportingVersion>
-        <serialization.xstreamVersion>0.2.12</serialization.xstreamVersion>
+        <serialization.xstreamVersion>0.2.14</serialization.xstreamVersion>
         <calculationVersion>1.1</calculationVersion>
         <providermanagementVersion>2.5.0</providermanagementVersion>
         <metadatamappingVersion>1.2.1</metadatamappingVersion>


### PR DESCRIPTION
Ticket : https://issues.openmrs.org/browse/TRUNK-5342
Added support for Migrating Encounter Diagnosis data to their new table.
This is only possible if one is running platform 2.2.