### PR TITLE
EA-153: NullPointerException in EncounterDomainWrapper when Encounter datetime is null

### DIFF
--- a/api/src/main/java/org/openmrs/module/emrapi/encounter/EncounterDomainWrapper.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/encounter/EncounterDomainWrapper.java
@@ -163,7 +163,7 @@ public class EncounterDomainWrapper implements DomainWrapper {
     /**
      * Associates the encounter with the specified visit
      * If the encounterDatetime has only a Date component, adds a time component (if necessary) based on our business logic:
-     * if this is an open visit and encounter date = today, consider a real-tiome transaction and we stamp with the current time,
+     * if this is an open visit and encounter date = today, consider a real-time transaction and we stamp with the current time,
      * otherwise we add a time component (if necessary) to make sure the encounter falls within the specified visit
      *
      * @param visit
@@ -282,6 +282,6 @@ public class EncounterDomainWrapper implements DomainWrapper {
     }
 
     private boolean dateHasTimeComponent(Date date) {
-        return !new DateTime(date).equals(new DateMidnight(date));
+        return date != null && !new DateTime(date).equals(new DateMidnight(date));
     }
 }

--- a/api/src/test/java/org/openmrs/module/emrapi/encounter/EncounterDomainWrapperTest.java
+++ b/api/src/test/java/org/openmrs/module/emrapi/encounter/EncounterDomainWrapperTest.java
@@ -252,6 +252,25 @@ public class EncounterDomainWrapperTest {
     }
 
     @Test
+    public void test_attachToVisit_shouldSetStartDateToCurrentDatetimeForOpenVisitWithNoEncounterDatetime() throws Exception {
+        DateTime currentDate = new DateTime().withTime(0, 0, 0, 0);
+
+        Encounter encounter = new Encounter();
+        EncounterDomainWrapper encounterWrapper = new EncounterDomainWrapper(encounter);
+
+        Visit visit = new Visit();
+        visit.setStartDatetime(currentDate.withTimeAtStartOfDay().toDate());
+
+        Date shouldBeLessThenEncounterDatetime = new Date();
+        encounterWrapper.attachToVisit(visit);
+        Date shouldBeGreaterThanEncounterDatetime = new Date();
+
+        assertThat(encounter.getEncounterDatetime(), greaterThanOrEqualTo(shouldBeLessThenEncounterDatetime));
+        assertThat(encounter.getEncounterDatetime(), lessThanOrEqualTo(shouldBeGreaterThanEncounterDatetime));
+        assertThat(encounter.getVisit(), is(visit));
+    }
+
+    @Test
     public void test_attachToVisit_shouldPropagateEncounterDatetimeChangeToObs()
             throws Exception {
 


### PR DESCRIPTION
JIRA Issue: https://issues.openmrs.org/browse/EA-153

This is a pretty trivial bug-fix with a test case added.