### PR TITLE
RA-950: Add LastVisit and EditVisit require an EndDate

### DIFF
--- a/api/src/main/java/org/openmrs/module/emrapi/adt/AdtServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/adt/AdtServiceImpl.java
@@ -784,16 +784,16 @@ public class AdtServiceImpl extends BaseOpenmrsService implements AdtService {
     @Transactional
     public VisitDomainWrapper createRetrospectiveVisit(Patient patient, Location location, Date startDatetime, Date stopDatetime)
         throws ExistingVisitDuringTimePeriodException {
-
+        
         if (startDatetime.after(new Date())) {
             throw new IllegalArgumentException("emrapi.retrospectiveVisit.startDateCannotBeInFuture");
         }
 
-        if (stopDatetime.after(new Date())) {
+        if (stopDatetime != null && stopDatetime.after(new Date())) {
             throw new IllegalArgumentException("emrapi.retrospectiveVisit.stopDateCannotBeInFuture");
         }
 
-        if (startDatetime.after(stopDatetime)) {
+        if (stopDatetime != null && startDatetime.after(stopDatetime)) {
             throw new IllegalArgumentException("emrapi.retrospectiveVisit.endDateBeforeStartDateMessage");
         }
 


### PR DESCRIPTION
https://issues.openmrs.org/browse/RA-950
I did the following
1.Enabled adding a past visit with a start date but no end date
2.But disabled adding a past visit with a start date but no end date if this would overlap with another existing visit
3.Enabled editing a closed visit and remove its end date
4.But disabled editing a closed visit and remove its end date if this would overlap with another existing visit
Other changes are in core-apps https://github.com/openmrs/openmrs-module-coreapps/pull/275