### PR TITLE
EA-154| EmrApiVisitAssignmentHandler; Check for Visit Id in associated visit to make sure it is a saved visit

### DIFF
--- a/api/src/main/java/org/openmrs/module/emrapi/adt/EmrApiVisitAssignmentHandler.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/adt/EmrApiVisitAssignmentHandler.java
@@ -80,7 +80,7 @@ public class EmrApiVisitAssignmentHandler extends BaseEncounterVisitHandler impl
     public void beforeCreateEncounter(Encounter encounter) {
 
         //Do nothing if the encounter already belongs to a visit.
-        if (encounter.getVisit() != null) {
+        if (encounter.getVisit() != null && encounter.getVisit().getVisitId() != null) {
             return;
         }
 


### PR DESCRIPTION
Jira issue: https://issues.openmrs.org/browse/EA-154
OpenMRS Talk: https://talk.openmrs.org/t/emrapivisitassignmenthandler-should-check-for-null-visitid/27359