### PR TITLE
EA-160 Error when entering recent visits in Reference Application on PostgreSQL

### DIFF
--- a/api/src/main/resources/hql/visit_primary_diagnoses.hql
+++ b/api/src/main/resources/hql/visit_primary_diagnoses.hql
@@ -1,11 +1,9 @@
-select
-  o.obsGroup
-from
-  Obs o
-where
+select o1 from Obs o
+inner join o.obsGroup o1	
+where 
   o.voided = 'false'
   and (o.encounter.visit = :visitId)
   and o.concept.conceptId = :diagnosisOrderConceptId
   and o.valueCoded.conceptId = :primaryOrderConceptId
-group by o.encounter, o.obsGroup
+group by o.encounter, o1.obsId, o.encounter.encounterDatetime
 order by o.encounter.encounterDatetime desc, o.obsGroup.obsDatetime desc


### PR DESCRIPTION
**Changes I made**
Currently the query that gets executed is : https://pastebin.com/rhPBFYmW . This gives an error in PostgreSQL:  https://pastebin.com/D9ZYPiXA . In order to get control of join I added the join part myself and not allowed hibernate to do it. 
After the change, the query that gets executed is : https://pastebin.com/t6gKAxuC 

Why change group by ? 
Because these fields were required in group by for PostgreSQL else you get an error. 
 
Will it effect the query ? 
o1.obsId will not as it is same as o.obsGroup 

o.encounter.encounterDatetime will not effect as it is unique of each obsId and encounterId.

I have tested the change on both MySQL and PostgreSQL and it is working fine.

**Link to ticket**
https://issues.openmrs.org/browse/EA-160 