### PR TITLE
EA-162: Add support for FHIR condition resource

### DIFF
--- a/fhir-condition/pom.xml
+++ b/fhir-condition/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>emrapi</artifactId>
+        <groupId>org.openmrs.module</groupId>
+        <version>1.31.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>emrapi-fhir-condition</artifactId>
+    <packaging>jar</packaging>
+    <name>EMR API Fhir condition</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.openmrs.api</groupId>
+            <artifactId>openmrs-api</artifactId>
+            <version>${openMRSVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-condition-list</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>fhir2-api</artifactId>
+            <version>${openmrsModuleFhirVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombokVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openmrs.api</groupId>
+            <artifactId>openmrs-api</artifactId>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.openmrs.test</groupId>
+            <artifactId>openmrs-test</artifactId>
+            <type>pom</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <lombokVersion>1.18.10</lombokVersion>
+        <openMRSVersion>2.0.5</openMRSVersion>
+        <openmrsModuleFhirVersion>1.0.0</openmrsModuleFhirVersion>
+    </properties>
+
+</project>

--- a/fhir-condition/src/main/java/org/openmrs/module/fhir2conditions/api/dao/impl/FhirConditionDaoImpl.java
+++ b/fhir-condition/src/main/java/org/openmrs/module/fhir2conditions/api/dao/impl/FhirConditionDaoImpl.java
@@ -1,0 +1,114 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2conditions.api.dao.impl;
+
+import static org.hibernate.criterion.Restrictions.eq;
+
+import java.util.List;
+import java.util.Optional;
+
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import org.hibernate.Criteria;
+import org.openmrs.annotation.Authorized;
+import org.openmrs.annotation.OpenmrsProfile;
+import org.openmrs.module.emrapi.conditionslist.Condition;
+import org.openmrs.module.emrapi.conditionslist.PrivilegeConstants;
+import org.openmrs.module.fhir2.FhirConstants;
+import org.openmrs.module.fhir2.api.dao.FhirConditionDao;
+import org.openmrs.module.fhir2.api.dao.impl.BaseFhirDao;
+import org.openmrs.module.fhir2.api.search.param.SearchParameterMap;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+
+@Primary
+@Component("fhir.condition.fhirConditionDaoImpl")
+@OpenmrsProfile(openmrsPlatformVersion = "2.0.* - 2.1.*")
+public class FhirConditionDaoImpl extends BaseFhirDao<org.openmrs.module.emrapi.conditionslist.Condition> implements FhirConditionDao<org.openmrs.module.emrapi.conditionslist.Condition> {
+
+    @Override
+    @Authorized(PrivilegeConstants.GET_CONDITIONS)
+    public Condition get(@Nonnull String uuid) {
+        return super.get(uuid);
+    }
+
+    @Override
+    @Authorized(PrivilegeConstants.EDIT_CONDITIONS)
+    public Condition createOrUpdate(@Nonnull Condition newEntry) {
+        return super.createOrUpdate(newEntry);
+    }
+
+    @Override
+    @Authorized(PrivilegeConstants.EDIT_CONDITIONS)
+    public Condition delete(@Nonnull String uuid) {
+        return super.delete(uuid);
+    }
+
+    @Override
+    @Authorized(PrivilegeConstants.GET_CONDITIONS)
+    public List<String> getSearchResultUuids(@Nonnull SearchParameterMap theParams) {
+        return super.getSearchResultUuids(theParams);
+    }
+
+    @Override
+    @Authorized(PrivilegeConstants.GET_CONDITIONS)
+    public List<Condition> getSearchResults(@Nonnull SearchParameterMap theParams,
+                                            @Nonnull List<String> matchingResourceUuids, int firstResult, int lastResult) {
+        return super.getSearchResults(theParams, matchingResourceUuids, firstResult, lastResult);
+    }
+
+    @Override
+    protected void setupSearchParams(Criteria criteria, SearchParameterMap theParams) {
+        theParams.getParameters().forEach(entry -> {
+            switch (entry.getKey()) {
+                case FhirConstants.PATIENT_REFERENCE_SEARCH_HANDLER:
+                    entry.getValue()
+                            .forEach(param -> handlePatientReference(criteria, (ReferenceAndListParam) param.getParam()));
+                    break;
+                case FhirConstants.CODED_SEARCH_HANDLER:
+                    entry.getValue().forEach(param -> handleCode(criteria, (TokenAndListParam) param.getParam()));
+                    break;
+                case FhirConstants.CONDITION_CLINICAL_STATUS_HANDLER:
+                    entry.getValue().forEach(param -> handleClinicalStatus(criteria, (TokenAndListParam) param.getParam()));
+                    break;
+                case FhirConstants.DATE_RANGE_SEARCH_HANDLER:
+                    entry.getValue()
+                            .forEach(param -> handleDateRange(param.getPropertyName(), (DateRangeParam) param.getParam())
+                                    .ifPresent(criteria::add));
+                    break;
+            }
+        });
+    }
+
+    private void handleCode(Criteria criteria, TokenAndListParam code) {
+        if (code != null) {
+            criteria.createAlias("condition.coded", "cd");
+            handleCodeableConcept(criteria, code, "cd", "map", "term").ifPresent(criteria::add);
+        }
+    }
+
+    private void handleClinicalStatus(Criteria criteria, TokenAndListParam status) {
+        handleAndListParam(status, tokenParam -> Optional.of(eq("clinicalStatus", convertStatus(tokenParam.getValue()))))
+                .ifPresent(criteria::add);
+    }
+
+    private Condition.Status convertStatus(String status) {
+        if ("active".equalsIgnoreCase(status)) {
+            return Condition.Status.ACTIVE;
+        }
+        if ("inactive".equalsIgnoreCase(status)) {
+            return Condition.Status.INACTIVE;
+        }
+        return Condition.Status.HISTORY_OF;
+    }
+}

--- a/fhir-condition/src/main/java/org/openmrs/module/fhir2conditions/api/impl/FhirConditionServiceImpl.java
+++ b/fhir-condition/src/main/java/org/openmrs/module/fhir2conditions/api/impl/FhirConditionServiceImpl.java
@@ -1,0 +1,67 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2conditions.api.impl;
+
+import ca.uhn.fhir.rest.annotation.Sort;
+import ca.uhn.fhir.rest.api.SortSpec;
+import ca.uhn.fhir.rest.api.server.IBundleProvider;
+import ca.uhn.fhir.rest.param.DateRangeParam;
+import ca.uhn.fhir.rest.param.QuantityAndListParam;
+import ca.uhn.fhir.rest.param.ReferenceAndListParam;
+import ca.uhn.fhir.rest.param.TokenAndListParam;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import org.openmrs.annotation.OpenmrsProfile;
+import org.openmrs.module.fhir2.FhirConstants;
+import org.openmrs.module.fhir2.api.FhirConditionService;
+import org.openmrs.module.fhir2.api.dao.FhirConditionDao;
+import org.openmrs.module.fhir2.api.impl.BaseFhirService;
+import org.openmrs.module.fhir2.api.search.SearchQuery;
+import org.openmrs.module.fhir2.api.search.param.SearchParameterMap;
+import org.openmrs.module.fhir2.api.translators.ConditionTranslator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Primary
+@Transactional
+@Setter(AccessLevel.PACKAGE)
+@Getter(AccessLevel.PROTECTED)
+@Component("fhir2conditions.fhirConditionServiceImpl")
+@OpenmrsProfile(openmrsPlatformVersion = "2.0.* - 2.1.*")
+public class FhirConditionServiceImpl extends BaseFhirService<org.hl7.fhir.r4.model.Condition, org.openmrs.module.emrapi.conditionslist.Condition> implements FhirConditionService {
+
+    @Autowired
+    private FhirConditionDao<org.openmrs.module.emrapi.conditionslist.Condition> dao;
+
+    @Autowired
+    private ConditionTranslator<org.openmrs.module.emrapi.conditionslist.Condition> translator;
+
+    @Autowired
+    private SearchQuery<org.openmrs.module.emrapi.conditionslist.Condition, org.hl7.fhir.r4.model.Condition, FhirConditionDao<org.openmrs.module.emrapi.conditionslist.Condition>, ConditionTranslator<org.openmrs.module.emrapi.conditionslist.Condition>> searchQuery;
+
+    @Override
+    public IBundleProvider searchConditions(ReferenceAndListParam patientParam, TokenAndListParam code,
+                                            TokenAndListParam clinicalStatus, DateRangeParam onsetDate, QuantityAndListParam onsetAge,
+                                            DateRangeParam recordedDate, TokenAndListParam tokenAndListParam2, DateRangeParam dateRangeParam2, @Sort SortSpec sort) {
+
+        SearchParameterMap theParams = new SearchParameterMap()
+                .addParameter(FhirConstants.PATIENT_REFERENCE_SEARCH_HANDLER, patientParam)
+                .addParameter(FhirConstants.CODED_SEARCH_HANDLER, code)
+                .addParameter(FhirConstants.CONDITION_CLINICAL_STATUS_HANDLER, clinicalStatus)
+                .addParameter(FhirConstants.QUANTITY_SEARCH_HANDLER, onsetAge)
+                .addParameter(FhirConstants.DATE_RANGE_SEARCH_HANDLER, "onsetDate", onsetDate)
+                .addParameter(FhirConstants.DATE_RANGE_SEARCH_HANDLER, "dateCreated", recordedDate).setSortSpec(sort);
+
+        return searchQuery.getQueryResults(theParams, dao, translator);
+    }
+}

--- a/fhir-condition/src/main/java/org/openmrs/module/fhir2conditions/api/translators/impl/ConditionStatusTranslatorImpl.java
+++ b/fhir-condition/src/main/java/org/openmrs/module/fhir2conditions/api/translators/impl/ConditionStatusTranslatorImpl.java
@@ -1,0 +1,77 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2conditions.api.translators.impl;
+
+import javax.annotation.Nonnull;
+
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.openmrs.annotation.OpenmrsProfile;
+import org.openmrs.module.emrapi.conditionslist.Condition;
+import org.openmrs.module.fhir2.FhirConstants;
+import org.openmrs.module.fhir2.api.translators.ConditionClinicalStatusTranslator;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Primary
+@Component("fhir.condition.conditionStatusTranslator")
+@OpenmrsProfile(openmrsPlatformVersion = "2.0.* - 2.1.*")
+public class ConditionStatusTranslatorImpl implements ConditionClinicalStatusTranslator<Condition.Status> {
+
+    @Override
+    public CodeableConcept toFhirResource(@Nonnull Condition.Status status) {
+        if (status == null) {
+            return null;
+        }
+
+        CodeableConcept codeableConcept = new CodeableConcept();
+        switch (status) {
+            case ACTIVE:
+                codeableConcept.addCoding().setCode(status.toString().toLowerCase()).setDisplay("Active")
+                        .setSystem(FhirConstants.CONDITION_CLINICAL_STATUS_SYSTEM_URI);
+                break;
+            case INACTIVE:
+                codeableConcept.addCoding().setCode(status.toString().toLowerCase()).setDisplay("Inactive")
+                        .setSystem(FhirConstants.CONDITION_CLINICAL_STATUS_SYSTEM_URI);
+                break;
+            default:
+                codeableConcept.addCoding().setCode("inactive").setDisplay("Inactive")
+                        .setSystem(FhirConstants.CONDITION_CLINICAL_STATUS_SYSTEM_URI);
+                break;
+        }
+
+        return codeableConcept;
+    }
+
+    @Override
+    public Condition.Status toOpenmrsType(@Nonnull CodeableConcept codeableConcept) {
+        if (codeableConcept == null) {
+            return null;
+        }
+
+        return codeableConcept.getCoding().stream()
+                .filter(coding -> coding.getSystem().equals(FhirConstants.CONDITION_CLINICAL_STATUS_SYSTEM_URI))
+                .map(this::getClinicalStatus).findFirst().orElse(null);
+    }
+
+    private Condition.Status getClinicalStatus(Coding coding) {
+        if (coding.getCode() == null) {
+            return Condition.Status.INACTIVE;
+        }
+
+        switch (coding.getCode().trim().toLowerCase()) {
+            case "active":
+                return Condition.Status.ACTIVE;
+            case "inactive":
+            default:
+                return Condition.Status.INACTIVE;
+        }
+    }
+}

--- a/fhir-condition/src/main/java/org/openmrs/module/fhir2conditions/api/translators/impl/ConditionTranslatorImpl.java
+++ b/fhir-condition/src/main/java/org/openmrs/module/fhir2conditions/api/translators/impl/ConditionTranslatorImpl.java
@@ -1,0 +1,112 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2conditions.api.translators.impl;
+
+import lombok.AccessLevel;
+import lombok.Setter;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.StringType;
+import org.openmrs.User;
+import org.openmrs.annotation.OpenmrsProfile;
+import org.openmrs.module.emrapi.conditionslist.Condition;
+import org.openmrs.module.fhir2.FhirConstants;
+import org.openmrs.module.fhir2.api.translators.ConceptTranslator;
+import org.openmrs.module.fhir2.api.translators.ConditionTranslator;
+import org.openmrs.module.fhir2.api.translators.PatientReferenceTranslator;
+import org.openmrs.module.fhir2.api.translators.PractitionerReferenceTranslator;
+import org.openmrs.module.fhir2.api.translators.ProvenanceTranslator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
+
+import static org.apache.commons.lang3.Validate.notNull;
+
+@Setter(AccessLevel.PACKAGE)
+@Component("fhir.condition.conditionTranslatorImpl")
+@OpenmrsProfile(openmrsPlatformVersion = "2.0.* - 2.1.*")
+public class ConditionTranslatorImpl implements ConditionTranslator<Condition> {
+
+    @Autowired
+    private PatientReferenceTranslator patientReferenceTranslator;
+
+    @Autowired
+    private ConceptTranslator conceptTranslator;
+
+    @Autowired
+    private PractitionerReferenceTranslator<User> practitionerReferenceTranslator;
+
+    @Autowired
+    private ProvenanceTranslator<Condition> provenanceTranslator;
+
+    @Autowired
+    private ConditionStatusTranslatorImpl conditionStatusTranslator;
+
+    @Override
+    public org.hl7.fhir.r4.model.Condition toFhirResource(@Nonnull Condition condition) {
+        notNull(condition, "The OpenMRS Condition object should not be null");
+
+        org.hl7.fhir.r4.model.Condition fhirCondition = new org.hl7.fhir.r4.model.Condition();
+        fhirCondition.setId(condition.getUuid());
+        fhirCondition.setSubject(patientReferenceTranslator.toFhirResource(condition.getPatient()));
+        fhirCondition.setClinicalStatus(conditionStatusTranslator.toFhirResource(condition.getStatus()));
+
+        if (condition.getConcept() != null) {
+            fhirCondition.setCode(conceptTranslator.toFhirResource(condition.getConcept()));
+            if (condition.getConditionNonCoded() != null) {
+                Extension extension = new Extension();
+                extension.setUrl(FhirConstants.OPENMRS_FHIR_EXT_NON_CODED_CONDITION);
+                extension.setValue(new StringType(condition.getConditionNonCoded()));
+               fhirCondition.addExtension(extension);
+            }
+        }
+
+        fhirCondition.setOnset(new DateTimeType().setValue(condition.getOnsetDate()));
+        fhirCondition.setRecorder(practitionerReferenceTranslator.toFhirResource(condition.getCreator()));
+        fhirCondition.setRecordedDate(condition.getDateCreated());
+        fhirCondition.getMeta().setLastUpdated(condition.getDateChanged());
+        fhirCondition.addContained(provenanceTranslator.getCreateProvenance(condition));
+        fhirCondition.addContained(provenanceTranslator.getUpdateProvenance(condition));
+
+        return fhirCondition;
+    }
+
+    @Override
+    public Condition toOpenmrsType(@Nonnull org.hl7.fhir.r4.model.Condition condition) {
+        notNull(condition, "The Condition object should not be null");
+        return this.toOpenmrsType(new Condition(), condition);
+    }
+
+    @Override
+    public Condition toOpenmrsType(@Nonnull Condition existingCondition, @Nonnull org.hl7.fhir.r4.model.Condition condition) {
+        notNull(existingCondition, "The existing OpenMRS Condition object should not be null");
+        notNull(condition, "The Condition object should not be null");
+        existingCondition.setUuid(condition.getId());
+        existingCondition.setPatient(patientReferenceTranslator.toOpenmrsType(condition.getSubject()));
+        existingCondition.setStatus(conditionStatusTranslator.toOpenmrsType(condition.getClinicalStatus()));
+
+        if (!condition.getCode().isEmpty()) {
+            existingCondition.setConcept(conceptTranslator.toOpenmrsType(condition.getCode()));
+        }
+        Optional<Extension> extension = Optional
+                .ofNullable(condition.getExtensionByUrl(FhirConstants.OPENMRS_FHIR_EXT_NON_CODED_CONDITION));
+        extension.ifPresent(value -> existingCondition.setConditionNonCoded(String.valueOf(value.getValue())));
+
+        existingCondition.setOnsetDate(condition.getOnsetDateTimeType().getValue());
+        existingCondition.setCreator(practitionerReferenceTranslator.toOpenmrsType(condition.getRecorder()));
+        existingCondition.setDateCreated(condition.getRecordedDate());
+        existingCondition.setDateChanged(condition.getMeta().getLastUpdated());
+
+        return existingCondition;
+    }
+}

--- a/fhir-condition/src/main/resources/moduleApplicationContext.xml
+++ b/fhir-condition/src/main/resources/moduleApplicationContext.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
+<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://www.springframework.org/schema/beans" xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+  		    http://www.springframework.org/schema/beans/spring-beans-4.1.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-4.1.xsd">
+    <context:annotation-config />
+</beans>

--- a/fhir-condition/src/test/java/org/openmrs/module/fhir2conditions/api/impl/FhirConditionServiceImplTest.java
+++ b/fhir-condition/src/test/java/org/openmrs/module/fhir2conditions/api/impl/FhirConditionServiceImplTest.java
@@ -1,0 +1,73 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2conditions.api.impl;
+
+import ca.uhn.fhir.rest.server.exceptions.ResourceNotFoundException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openmrs.module.emrapi.conditionslist.Condition;
+import org.openmrs.module.fhir2.api.dao.FhirConditionDao;
+import org.openmrs.module.fhir2.api.translators.ConditionTranslator;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FhirConditionServiceImplTest {
+
+    private static final String CONDITION_UUID = "ca0dfd38-ee20-41a6-909e-7d84247ca192";
+
+    private static final String WRONG_CONDITION_UUID = "tx0dfd38-ee20-41a6-909e-7d84247c8340";
+
+    @Mock
+    private FhirConditionDao<Condition> dao;
+
+    @Mock
+    private ConditionTranslator<Condition> translator;
+
+    private FhirConditionServiceImpl conditionService;
+
+    private Condition openmrsCondition;
+
+    private org.hl7.fhir.r4.model.Condition fhirCondition;
+
+    @Before
+    public void setup() {
+        conditionService = new FhirConditionServiceImpl();
+        conditionService.setDao(dao);
+        conditionService.setTranslator(translator);
+
+        openmrsCondition = new Condition();
+        openmrsCondition.setUuid(CONDITION_UUID);
+
+        fhirCondition = new org.hl7.fhir.r4.model.Condition();
+        fhirCondition.setId(CONDITION_UUID);
+    }
+
+    @Test
+    public void getConditionByUuid_shouldReturnCondition() {
+        when(dao.get(CONDITION_UUID)).thenReturn(openmrsCondition);
+        when(translator.toFhirResource(openmrsCondition)).thenReturn(fhirCondition);
+        org.hl7.fhir.r4.model.Condition result = conditionService.get(CONDITION_UUID);
+        assertThat(result, notNullValue());
+        assertThat(result.getId(), equalTo(CONDITION_UUID));
+    }
+
+    @Test(expected = ResourceNotFoundException.class)
+    public void getConditionByWrongUuid_shouldReturnCondition() {
+        assertThat(conditionService.get(WRONG_CONDITION_UUID), nullValue());
+    }
+}

--- a/fhir-condition/src/test/java/org/openmrs/module/fhir2conditions/api/translators/impl/ConditionStatusTranslatorImplTest.java
+++ b/fhir-condition/src/test/java/org/openmrs/module/fhir2conditions/api/translators/impl/ConditionStatusTranslatorImplTest.java
@@ -1,0 +1,85 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2conditions.api.translators.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.module.emrapi.conditionslist.Condition;
+import org.openmrs.module.fhir2.FhirConstants;
+
+public class ConditionStatusTranslatorImplTest {
+
+    private static final String ACTIVE = "active";
+
+    private static final String INACTIVE = "inactive";
+
+    private ConditionStatusTranslatorImpl statusTranslator;
+
+    @Before
+    public void setUp() {
+        this.statusTranslator = new ConditionStatusTranslatorImpl();
+    }
+
+    @Test
+    public void shouldMapOpenMrsActiveToFHIRActive() {
+        CodeableConcept codeableConcept = statusTranslator.toFhirResource(Condition.Status.ACTIVE);
+        assertThat(codeableConcept, notNullValue());
+        assertThat(codeableConcept.getCodingFirstRep().getCode(), equalTo(ACTIVE));
+        assertThat(codeableConcept.getCodingFirstRep().getDisplay(), equalTo("Active"));
+        assertThat(codeableConcept.getCodingFirstRep().getSystem(),
+                equalTo(FhirConstants.CONDITION_CLINICAL_STATUS_SYSTEM_URI));
+    }
+
+    @Test
+    public void shouldMapOpenMrsInActiveToFHIRInActive() {
+        CodeableConcept codeableConcept = statusTranslator.toFhirResource(Condition.Status.INACTIVE);
+        assertThat(codeableConcept, notNullValue());
+        assertThat(codeableConcept.getCodingFirstRep().getCode(), equalTo(INACTIVE));
+        assertThat(codeableConcept.getCodingFirstRep().getDisplay(), equalTo("Inactive"));
+        assertThat(codeableConcept.getCodingFirstRep().getSystem(),
+                equalTo(FhirConstants.CONDITION_CLINICAL_STATUS_SYSTEM_URI));
+    }
+
+    @Test
+    public void shouldMapOpenMrsHistoryOfToFHIRInActive() {
+        CodeableConcept codeableConcept = statusTranslator.toFhirResource(Condition.Status.HISTORY_OF);
+        assertThat(codeableConcept, notNullValue());
+        assertThat(codeableConcept.getCodingFirstRep().getCode(), equalTo(INACTIVE));
+        assertThat(codeableConcept.getCodingFirstRep().getSystem(),
+                equalTo(FhirConstants.CONDITION_CLINICAL_STATUS_SYSTEM_URI));
+    }
+
+    @Test
+    public void shouldMapFHIRActiveToOpenMrsActiveClinicalCondition() {
+        CodeableConcept codeableConcept = new CodeableConcept();
+        Coding coding = new Coding();
+        coding.setCode(ACTIVE);
+        coding.setSystem(FhirConstants.CONDITION_CLINICAL_STATUS_SYSTEM_URI);
+        codeableConcept.addCoding(coding);
+        assertThat(statusTranslator.toOpenmrsType(codeableConcept), is(Condition.Status.ACTIVE));
+    }
+
+    @Test
+    public void shouldMapFHIRInActiveToOpenMrsInActive() {
+        CodeableConcept codeableConcept = new CodeableConcept();
+        Coding coding = new Coding();
+        coding.setCode(INACTIVE);
+        coding.setSystem(FhirConstants.CONDITION_CLINICAL_STATUS_SYSTEM_URI);
+        codeableConcept.addCoding(coding);
+        assertThat(statusTranslator.toOpenmrsType(codeableConcept), is(Condition.Status.INACTIVE));
+    }
+}

--- a/fhir-condition/src/test/java/org/openmrs/module/fhir2conditions/api/translators/impl/ConditionTranslatorImplTest.java
+++ b/fhir-condition/src/test/java/org/openmrs/module/fhir2conditions/api/translators/impl/ConditionTranslatorImplTest.java
@@ -1,0 +1,342 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.fhir2conditions.api.translators.impl;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matchers;
+import org.hl7.fhir.r4.model.CodeableConcept;
+import org.hl7.fhir.r4.model.Coding;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.hl7.fhir.r4.model.IdType;
+import org.hl7.fhir.r4.model.Provenance;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.StringType;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openmrs.Concept;
+import org.openmrs.Patient;
+import org.openmrs.PatientIdentifier;
+import org.openmrs.PatientIdentifierType;
+import org.openmrs.PersonName;
+import org.openmrs.User;
+import org.openmrs.module.emrapi.conditionslist.Condition;
+import org.openmrs.module.fhir2.FhirConstants;
+import org.openmrs.module.fhir2.api.translators.ConceptTranslator;
+import org.openmrs.module.fhir2.api.translators.PatientReferenceTranslator;
+import org.openmrs.module.fhir2.api.translators.PractitionerReferenceTranslator;
+import org.openmrs.module.fhir2.api.translators.ProvenanceTranslator;
+import org.openmrs.module.fhir2.api.util.FhirUtils;
+import uk.co.it.modular.hamcrest.date.DateMatchers;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConditionTranslatorImplTest {
+
+    private static final String CONDITION_UUID = "00af6f0f-ed07-4cef-b0f1-a76a999db987";
+
+    private static final String PATIENT_UUID = "258797db-1524-4a13-9f09-2881580b0f5b";
+
+    private static final String PRACTITIONER_UUID = "2ffb1a5f-bcd3-4243-8f40-78edc2642789";
+
+    private static final String FAMILY_NAME = "Wambua";
+
+    private static final String GIVEN_NAME = "Janet";
+
+    private static final String TEST_IDENTIFIER_TYPE = "test identifierType";
+
+    private static final String IDENTIFIER = "identifier";
+
+    private static final String SYSTEM = "urn:oid:2.16.840.1.113883.3.7201";
+
+    private static final Integer CODE = 102309;
+
+    private static final Integer CONDITION_NON_CODED = 5602;
+
+    private static final String CONDITION_NON_CODED_TEXT = "condition non coded";
+
+    private static final String CONDITION_NON_CODED_VALUE = "Other";
+
+    private static final String CONCEPT_UUID = "31d754f5-3e9e-4ca3-805c-87f97a1f5e4b";
+
+    private static final String PRACTITIONER_REFERENCE = FhirConstants.PRACTITIONER + "/" + PRACTITIONER_UUID;
+
+    @Mock
+    private PatientReferenceTranslator patientReferenceTranslator;
+
+    @Mock
+    private ConceptTranslator conceptTranslator;
+
+    @Mock
+    private PractitionerReferenceTranslator<User> practitionerReferenceTranslator;
+
+    @Mock
+    private ProvenanceTranslator<Condition> provenanceTranslator;
+
+    @Mock
+    private ConditionStatusTranslatorImpl conditionStatusTranslator;
+
+    private ConditionTranslatorImpl conditionTranslator;
+
+    private Condition openMrsCondition;
+
+    private org.hl7.fhir.r4.model.Condition fhirCondition;
+
+    private Patient patient;
+
+    @Before
+    public void setUp() {
+        conditionTranslator = new ConditionTranslatorImpl();
+        conditionTranslator.setPatientReferenceTranslator(patientReferenceTranslator);
+        conditionTranslator.setConceptTranslator(conceptTranslator);
+        conditionTranslator.setPractitionerReferenceTranslator(practitionerReferenceTranslator);
+        conditionTranslator.setProvenanceTranslator(provenanceTranslator);
+        conditionTranslator.setConditionStatusTranslator(conditionStatusTranslator);
+    }
+
+    @Before
+    public void initCondition() {
+        PersonName name = new PersonName();
+        name.setGivenName(GIVEN_NAME);
+        name.setFamilyName(FAMILY_NAME);
+
+        PatientIdentifierType identifierType = new PatientIdentifierType();
+        identifierType.setName(TEST_IDENTIFIER_TYPE);
+
+        PatientIdentifier identifier = new PatientIdentifier();
+        identifier.setIdentifierType(identifierType);
+        identifier.setIdentifier(IDENTIFIER);
+
+        patient = new Patient();
+        patient.setUuid(PATIENT_UUID);
+        patient.addIdentifier(identifier);
+        patient.addName(name);
+
+        Reference patientRef = new Reference();
+        patientRef.setReference(PATIENT_UUID);
+
+        openMrsCondition = new Condition();
+        openMrsCondition.setUuid(CONDITION_UUID);
+        openMrsCondition.setPatient(patient);
+        openMrsCondition.setStatus(Condition.Status.ACTIVE);
+
+        fhirCondition = new org.hl7.fhir.r4.model.Condition();
+        fhirCondition.setId(CONDITION_UUID);
+        fhirCondition.setSubject(patientRef);
+    }
+
+    @Test
+    public void shouldTranslateConditionToOpenMrsType() {
+        Condition condition = conditionTranslator.toOpenmrsType(fhirCondition);
+        assertThat(condition, notNullValue());
+        assertThat(condition.getUuid(), notNullValue());
+        assertThat(condition.getUuid(), equalTo(CONDITION_UUID));
+    }
+
+    @Test
+    public void shouldTranslateConditionToFhirType() {
+        org.hl7.fhir.r4.model.Condition condition = conditionTranslator.toFhirResource(openMrsCondition);
+        assertThat(condition, notNullValue());
+        assertThat(condition.getId(), notNullValue());
+        assertThat(condition.getId(), equalTo(CONDITION_UUID));
+    }
+
+    @Test
+    public void shouldUpdateExistingCondition() {
+        org.hl7.fhir.r4.model.Condition theCondition = new org.hl7.fhir.r4.model.Condition();
+        theCondition.setId(CONDITION_UUID);
+        Condition condition = conditionTranslator.toOpenmrsType(openMrsCondition, theCondition);
+        assertThat(condition, notNullValue());
+    }
+
+    @Test
+    public void shouldTranslatePatientToSubjectFhirType() {
+        Reference patientRef = new Reference();
+        patientRef.setReference(PATIENT_UUID);
+        when(patientReferenceTranslator.toFhirResource(openMrsCondition.getPatient())).thenReturn(patientRef);
+        org.hl7.fhir.r4.model.Condition condition = conditionTranslator.toFhirResource(openMrsCondition);
+        assertThat(condition, notNullValue());
+        assertThat(condition.getSubject(), notNullValue());
+        assertThat(condition.getSubject().getReference(), equalTo(PATIENT_UUID));
+    }
+
+    @Test
+    public void shouldTranslateOpenMrsConditionOnsetDateToFhirType() {
+        openMrsCondition.setOnsetDate(new Date());
+        org.hl7.fhir.r4.model.Condition condition = conditionTranslator.toFhirResource(openMrsCondition);
+        assertThat(condition, notNullValue());
+        assertThat(condition.getOnsetDateTimeType().getValue(), notNullValue());
+        assertThat(condition.getOnsetDateTimeType().getValue(), DateMatchers.sameDay(new Date()));
+    }
+
+    @Test
+    public void shouldTranslateFhirConditionOnsetToOpenMrsOnsetDate() {
+        DateTimeType theDateTime = new DateTimeType();
+        theDateTime.setValue(new Date());
+        fhirCondition.setOnset(theDateTime);
+        Condition condition = conditionTranslator.toOpenmrsType(fhirCondition);
+        assertThat(condition, notNullValue());
+        assertThat(condition.getOnsetDate(), notNullValue());
+        assertThat(condition.getOnsetDate(), DateMatchers.sameDay(new Date()));
+    }
+
+    @Test
+    public void shouldTranslateConditionCodeToOpenMrsConcept() {
+        CodeableConcept codeableConcept = new CodeableConcept();
+        Coding coding = new Coding();
+        coding.setCode(CODE.toString());
+        coding.setSystem(SYSTEM);
+        codeableConcept.addCoding(coding);
+        fhirCondition.setCode(codeableConcept);
+        Concept concept = new Concept();
+        concept.setUuid(CONCEPT_UUID);
+        concept.setConceptId(CODE);
+        when(conceptTranslator.toOpenmrsType(codeableConcept)).thenReturn(concept);
+        Condition condition = conditionTranslator.toOpenmrsType(fhirCondition);
+        assertThat(condition, notNullValue());
+        assertThat(condition.getConcept(), notNullValue());
+        assertThat(condition.getConcept().getConceptId(), equalTo(CODE));
+    }
+
+    @Test
+    public void shouldTranslateConditionConceptToFhirType() {
+        Concept concept = new Concept();
+        concept.setUuid(CONCEPT_UUID);
+        concept.setConceptId(CODE);
+        CodeableConcept codeableConcept = new CodeableConcept();
+        Coding coding = new Coding();
+        coding.setCode(CODE.toString());
+        coding.setSystem(SYSTEM);
+        codeableConcept.addCoding(coding);
+        openMrsCondition.setConcept(concept);
+        when(conceptTranslator.toFhirResource(concept)).thenReturn(codeableConcept);
+        org.hl7.fhir.r4.model.Condition condition = conditionTranslator.toFhirResource(openMrsCondition);
+        assertThat(condition, notNullValue());
+        assertThat(condition.getCode(), notNullValue());
+        assertThat(condition.getCode().getCoding(), not(Matchers.<Coding>empty()));
+        assertThat(condition.getCode().getCoding().get(0).getCode(), equalTo(CODE.toString()));
+        assertThat(condition.getCode().getCoding().get(0).getSystem(), equalTo(SYSTEM));
+    }
+
+    @Test
+    public void shouldTranslateConditionNonCodedToOpenMrsType() {
+        CodeableConcept codeableConcept = new CodeableConcept();
+        Coding coding = new Coding();
+        coding.setCode(String.valueOf(CONDITION_NON_CODED));
+        coding.setDisplay(CONDITION_NON_CODED_VALUE);
+        codeableConcept.addCoding(coding);
+        Concept concept = new Concept();
+        concept.setConceptId(CONDITION_NON_CODED);
+        fhirCondition.setCode(codeableConcept);
+        fhirCondition.addExtension(FhirConstants.OPENMRS_FHIR_EXT_NON_CODED_CONDITION,
+                new StringType(CONDITION_NON_CODED_TEXT));
+        when(conceptTranslator.toOpenmrsType(codeableConcept)).thenReturn(concept);
+        Condition condition = conditionTranslator.toOpenmrsType(fhirCondition);
+        assertThat(condition, notNullValue());
+        assertThat(condition.getConcept(), equalTo(concept));
+        assertThat(condition.getConditionNonCoded(), notNullValue());
+        assertThat(condition.getConditionNonCoded(), equalTo(CONDITION_NON_CODED_TEXT));
+    }
+
+    @Test
+    public void shouldTranslateOpenMRSConditionNonCodedToFhirType() {
+        CodeableConcept codeableConcept = new CodeableConcept();
+        Coding coding = new Coding();
+        coding.setCode(String.valueOf(CONDITION_NON_CODED));
+        codeableConcept.addCoding(coding);
+        Concept concept = new Concept();
+        concept.setConceptId(CONDITION_NON_CODED);
+        openMrsCondition.setConcept(concept);
+        openMrsCondition.setConditionNonCoded(CONDITION_NON_CODED_TEXT);
+        when(conceptTranslator.toFhirResource(concept)).thenReturn(codeableConcept);
+        org.hl7.fhir.r4.model.Condition condition = conditionTranslator.toFhirResource(openMrsCondition);
+        assertThat(condition, notNullValue());
+        assertThat(condition.getCode(), notNullValue());
+        assertThat(condition.getCode().getCoding(), not(empty()));
+        assertThat(condition.getCode().getCoding().get(0).getCode(), equalTo(String.valueOf(CONDITION_NON_CODED)));
+    }
+
+    @Test
+    public void shouldTranslateConditionDateCreatedToRecordedDateFhirType() {
+        openMrsCondition.setDateCreated(new Date());
+        org.hl7.fhir.r4.model.Condition condition = conditionTranslator.toFhirResource(openMrsCondition);
+        assertThat(condition, notNullValue());
+        assertThat(condition.getRecordedDate(), notNullValue());
+        assertThat(condition.getRecordedDate(), DateMatchers.sameDay(new Date()));
+    }
+
+    @Test
+    public void shouldTranslateConditionRecordedDateToDateCreatedOpenMrsType() {
+        fhirCondition.setRecordedDate(new Date());
+        Condition condition = conditionTranslator.toOpenmrsType(fhirCondition);
+        assertThat(condition, notNullValue());
+        assertThat(condition.getDateCreated(), notNullValue());
+        assertThat(condition.getDateCreated(), DateMatchers.sameDay(new Date()));
+    }
+
+    @Test
+    public void shouldTranslateConditionRecorderToOpenmrsUser() {
+        Reference userRef = new Reference();
+        userRef.setReference(FhirConstants.PRACTITIONER + "/" + PRACTITIONER_UUID);
+        fhirCondition.setRecorder(userRef);
+        User user = new User();
+        user.setUuid(PRACTITIONER_UUID);
+        when(practitionerReferenceTranslator.toOpenmrsType(userRef)).thenReturn(user);
+        Condition condition = conditionTranslator.toOpenmrsType(fhirCondition);
+        assertThat(condition, notNullValue());
+        assertThat(condition.getCreator(), notNullValue());
+        assertThat(condition.getCreator().getUuid(), equalTo(PRACTITIONER_UUID));
+    }
+
+    @Test
+    public void shouldTranslateConditionCreatorToRecorderFhirType() {
+        User user = new User();
+        user.setUuid(PRACTITIONER_UUID);
+        Reference userRef = new Reference();
+        userRef.setReference(PRACTITIONER_REFERENCE);
+        openMrsCondition.setCreator(user);
+        when(practitionerReferenceTranslator.toFhirResource(user)).thenReturn(userRef);
+        org.hl7.fhir.r4.model.Condition condition = conditionTranslator.toFhirResource(openMrsCondition);
+        assertThat(condition, notNullValue());
+        assertThat(condition.getRecorder(), notNullValue());
+        assertThat(condition.getRecorder().getReference(), equalTo(PRACTITIONER_REFERENCE));
+    }
+
+    @Test
+    public void shouldAddProvenanceToConditionResource() {
+        Condition condition = new Condition();
+        condition.setUuid(CONDITION_UUID);
+        Provenance provenance = new Provenance();
+        provenance.setId(new IdType(FhirUtils.newUuid()));
+        when(provenanceTranslator.getCreateProvenance(condition)).thenReturn(provenance);
+        when(provenanceTranslator.getUpdateProvenance(condition)).thenReturn(provenance);
+
+        org.hl7.fhir.r4.model.Condition result = conditionTranslator.toFhirResource(condition);
+        List<Resource> resources = result.getContained();
+        assertThat(resources, Matchers.notNullValue());
+        assertThat(resources, Matchers.not(empty()));
+        assertThat(resources.stream().findAny().isPresent(), CoreMatchers.is(true));
+        assertThat(resources.stream().findAny().get().isResource(), CoreMatchers.is(true));
+        assertThat(resources.stream().findAny().get().getResourceType().name(),
+                Matchers.equalTo(Provenance.class.getSimpleName()));
+    }
+}

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -33,6 +33,12 @@
         </dependency>
         <dependency>
             <groupId>${project.parent.groupId}</groupId>
+            <artifactId>${project.parent.artifactId}-fhir-condition</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
             <artifactId>${project.parent.artifactId}-api-1.11</artifactId>
             <version>${project.parent.version}</version>
             <scope>compile</scope>
@@ -356,6 +362,7 @@
                                 <classpathDependencyExcludes>${project.parent.groupId}:${project.parent.artifactId}-api-1.9</classpathDependencyExcludes>
                                 <classpathDependencyExcludes>${project.parent.groupId}:${project.parent.artifactId}-api-1.11</classpathDependencyExcludes>
                                 <classpathDependencyExcludes>${project.parent.groupId}:${project.parent.artifactId}-api-1.12</classpathDependencyExcludes>
+                                <classpathDependencyExcludes>${project.parent.groupId}:${project.parent.artifactId}-fhir-condition</classpathDependencyExcludes>
                             </classpathDependencyExcludes>
                         </configuration>
                     </plugin>
@@ -387,6 +394,7 @@
                                 <classpathDependencyExcludes>${project.parent.groupId}:${project.parent.artifactId}-api-1.10</classpathDependencyExcludes>
                                 <classpathDependencyExcludes>${project.parent.groupId}:${project.parent.artifactId}-api-1.12</classpathDependencyExcludes>
 								<classpathDependencyExcludes>${project.parent.groupId}:${project.parent.artifactId}-web-2.2</classpathDependencyExcludes>
+								<classpathDependencyExcludes>${project.parent.groupId}:${project.parent.artifactId}-fhir-condition</classpathDependencyExcludes>
                             </classpathDependencyExcludes>
                         </configuration>
                     </plugin>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<module configVersion="1.2">
+<module configVersion="1.6">
 
     <!-- Module Properties -->
     <id>${project.parent.artifactId}</id>
@@ -16,7 +16,9 @@
     <!-- TRUNK-3751 prevents saying ${openmrsCoreVersion} when version is a SNAPSHOT-->
     <!-- / Module Properties -->
 
-
+    <aware_of_modules>
+        <aware_of_module>org.openmrs.module.fhir2</aware_of_module>
+    </aware_of_modules>
     <!-- Required Modules -->
     <require_modules>
         <require_module version="${reportingModuleVersion}">org.openmrs.module.reporting</require_module>
@@ -61,6 +63,16 @@
         <conditionalResource>
             <path>/lib/emrapi-web-2.2-${project.parent.version}.jar</path>
             <openmrsVersion>2.2.* - 2.*</openmrsVersion>
+        </conditionalResource>
+        <conditionalResource>
+            <path>/lib/emrapi-fhir-condition-${project.parent.version}.jar</path>
+            <loadIfModulesPresent>
+                <openmrsModule>
+                    <moduleId>org.openmrs.module.fhir2</moduleId>
+                    <version>1.*</version>
+                </openmrsModule>
+            </loadIfModulesPresent>
+            <openmrsVersion>2.0.5 - 2.1.*</openmrsVersion>
         </conditionalResource>
     </conditionalResources>
     <!-- / Conditional Resources -->

--- a/pom.xml
+++ b/pom.xml
@@ -36,10 +36,11 @@
         <module>api-2.2</module>
         <module>web-2.2</module>
         <module>condition-list</module>
+        <module>fhir-condition</module>
         <module>omod</module>
 	    <module>api-pre2.2</module>
 		<module>web-pre2.2</module>
-	</modules>
+    </modules>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -125,6 +126,22 @@
                 <artifactId>metadatamapping-api</artifactId>
                 <version>${metadatamappingVersion}</version>
                 <scope>provided</scope>
+            </dependency>
+
+            <!--Tests -->
+            <dependency>
+                <groupId>org.openmrs.test</groupId>
+                <artifactId>openmrs-test</artifactId>
+                <version>${openMRSVersion}</version>
+                <type>pom</type>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.openmrs.api</groupId>
+                <artifactId>openmrs-api</artifactId>
+                <version>${openMRSVersion}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Issue worked on:
https://issues.openmrs.org/browse/EA-162

This PR adds support for FHIR conditions by:
- Adding mapping from EMR condition to FHIR condition (R4 & R3)
- Adds new Dao layer to support FHIR search operations


**NOTE**
 In case someone wants to see this in action. I already uploaded `1.31.0-SNAPSHOT`of the EMR API module to the [openmrs-spa instance](https://openmrs-spa.org/openmrs).