### PR TITLE
EA-171 - Changed GP_LAST_VIEWED_PATIENT_SIZE_LIMIT validation to be d…

### DIFF
--- a/api/src/main/java/org/openmrs/module/emrapi/event/PatientViewedEventListener.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/event/PatientViewedEventListener.java
@@ -90,22 +90,17 @@ public class PatientViewedEventListener implements EventListener {
 		User user = userService.getUserByUuid(userUuid);
 		if (user != null && patientToAdd != null) {
 			EmrApiProperties emrProperties = Context.getRegisteredComponents(EmrApiProperties.class).iterator().next();
-			Integer limit = emrProperties.getLastViewedPatientSizeLimit();
-			List<Integer> patientIds = new ArrayList<Integer>(limit);
-			if (limit > 0) {
-				List<Patient> lastViewedPatients = GeneralUtils.getLastViewedPatients(user);
-				patientIds.add(patientToAdd.getId());
-				for (Patient p : lastViewedPatients) {
-					if (patientIds.size() == limit)
-						break;
-					if (patientIds.contains(p.getId()))
-						continue;
-					
-					patientIds.add(p.getId());
-				}
-				
-				Collections.reverse(patientIds);
+			List<Integer> patientIds = new ArrayList<Integer>();
+			List<Patient> lastViewedPatients = GeneralUtils.getLastViewedPatients(user);
+			patientIds.add(patientToAdd.getId());
+			for (Patient p : lastViewedPatients) {
+				if (patientIds.contains(p.getId()))
+					continue;
+
+				patientIds.add(p.getId());
 			}
+
+			Collections.reverse(patientIds);
 			
 			String property = StringUtils.join(patientIds, ",");
 			if (StringUtils.isNotBlank(property) && property.length() > 255) {

--- a/api/src/main/java/org/openmrs/module/emrapi/event/PatientViewedEventListener.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/event/PatientViewedEventListener.java
@@ -90,10 +90,14 @@ public class PatientViewedEventListener implements EventListener {
 		User user = userService.getUserByUuid(userUuid);
 		if (user != null && patientToAdd != null) {
 			EmrApiProperties emrProperties = Context.getRegisteredComponents(EmrApiProperties.class).iterator().next();
+			Integer limit = emrProperties.getLastViewedPatientSizeLimit();
 			List<Integer> patientIds = new ArrayList<Integer>();
 			List<Patient> lastViewedPatients = GeneralUtils.getLastViewedPatients(user);
 			patientIds.add(patientToAdd.getId());
 			for (Patient p : lastViewedPatients) {
+				if (patientIds.size() == limit)
+					break;
+
 				if (patientIds.contains(p.getId()))
 					continue;
 

--- a/api/src/main/java/org/openmrs/module/emrapi/utils/GeneralUtils.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/utils/GeneralUtils.java
@@ -29,8 +29,8 @@ import org.openmrs.module.emrapi.EmrApiConstants;
 import org.openmrs.util.LocaleUtility;
 import org.openmrs.util.OpenmrsConstants;
 import org.openmrs.util.OpenmrsUtil;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -44,7 +44,7 @@ import java.util.Date;
  */
 public class GeneralUtils {
 
-    private static Log log = LogFactory.getLog(GeneralUtils.class);
+    private static final Logger log = LoggerFactory.getLogger(GeneralUtils.class);
 
     /**
      * Given a user, returns the default locale (if any) for that user


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/EA-171

Changing the global property emrapi.lastViewedPatientSizeLimit has no effect on the number of shown patients (Last view patient page). 

This happens because emrapi.lastViewedPatientSizeLimit is only taken into account when OpenMrs is started / restarted.

Solution:
Change GP_LAST_VIEWED_PATIENT_SIZE_LIMIT validation to be done inside getDefaultLocale
The validation is now done every time the function is called