### PR TITLE
EA-172: Add an API for fetching last viewed patients

### DIFF
--- a/omod/src/main/java/org/openmrs/module/emrapi/web/rest/searchhandler/LastViewedPatientsSearchHandler.java
+++ b/omod/src/main/java/org/openmrs/module/emrapi/web/rest/searchhandler/LastViewedPatientsSearchHandler.java
@@ -27,15 +27,14 @@ import org.openmrs.module.webservices.rest.web.response.ResponseException;
 import org.springframework.stereotype.Component;
 import org.openmrs.module.emrapi.utils.GeneralUtils;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 
 @Component
 public class LastViewedPatientsSearchHandler implements SearchHandler {
 
-    private final SearchConfig searchConfig = new SearchConfig("default", RestConstants.VERSION_1 + "/patient", Arrays.asList(
-            "1.8.*", "1.9.*", "1.10.*", "1.11.*"), new SearchQuery.Builder("Allows you to find last viewed patients").withRequiredParameters("lastviewed")
+    private final SearchConfig searchConfig = new SearchConfig("lastViewedPatients", RestConstants.VERSION_1 + "/patient", 	Collections.singletonList("1.8.* - 9.*"), new SearchQuery.Builder("Allows you to find last viewed patients").withRequiredParameters("lastviewed")
             .build());
 
     /**


### PR DESCRIPTION
Issue: https://issues.openmrs.org/browse/EA-172

**Description:** 
Last viewed patients are displayed in "Find Patient Record" screen in the web client, however, these patients are saved in a table and displayed when needed. For other clients, e.g. Android, we will need the same. So, I suggest that we have a REST endpoint or query parameter to fetch the last viewed patients that we can use anywhere.