### PR TITLE
RA-1678 - Update on timezone fix that moves date interpretation to th…

### DIFF
--- a/condition-list/src/main/java/org/openmrs/module/emrapi/conditionslist/DateConverter.java
+++ b/condition-list/src/main/java/org/openmrs/module/emrapi/conditionslist/DateConverter.java
@@ -1,0 +1,64 @@
+package org.openmrs.module.emrapi.conditionslist;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * This converter mimics the behavior in the rest webservices ConversionUtil method for dates
+ * This ensures that the system timezone is used to interpret dates unless UTC is explicitly indicated
+ * This is implemented as a
+ */
+public class DateConverter {
+
+    public static final String ISO_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+
+    private static final Log log = LogFactory.getLog(DateConverter.class);
+
+    public static final List<String> SUPPORTED_FORMATS = Arrays.asList(
+            ISO_DATE_FORMAT,
+            "yyyy-MM-dd'T'HH:mm:ss.SSS",
+            "yyyy-MM-dd'T'HH:mm:ssZ",
+            "yyyy-MM-dd'T'HH:mm:ssXXX",
+            "yyyy-MM-dd'T'HH:mm:ss",
+            "yyyy-MM-dd HH:mm:ss",
+            "yyyy-MM-dd"
+    );
+
+    /**
+     * @return the given dateString parsed into a Date, defaulting to using the system timezone
+     */
+    public static Date deserialize(String dateString) {
+        if (StringUtils.isBlank(dateString)) {
+            return null;
+        }
+        for (String dateFormat : SUPPORTED_FORMATS) {
+            try {
+                return DateTime.parse(dateString, DateTimeFormat.forPattern(dateFormat)).toDate();
+            }
+            catch (Exception e) {
+                if (log.isTraceEnabled()) {
+                    log.trace("Unable to parse '" + dateString + "' using format " + dateFormat, e);
+                }
+            }
+        }
+        throw new RuntimeException("Unable to parse '" + dateString + "' using any of: " + SUPPORTED_FORMATS);
+    }
+
+    /**
+     * @return the given date, serialized in ISO format
+     */
+    public static String serialize(Date date) {
+        if (date == null) {
+            return null;
+        }
+        return new SimpleDateFormat(ISO_DATE_FORMAT).format(date);
+    }
+}

--- a/condition-list/src/main/java/org/openmrs/module/emrapi/conditionslist/contract/Condition.java
+++ b/condition-list/src/main/java/org/openmrs/module/emrapi/conditionslist/contract/Condition.java
@@ -17,9 +17,9 @@ public class Condition {
 	
 	private org.openmrs.module.emrapi.conditionslist.Condition.Status status;
 	
-	private Date onSetDate;
+	private String onSetDate;
 	
-	private Date endDate;
+	private String endDate;
 	
 	private Concept endReason;
 	
@@ -75,19 +75,19 @@ public class Condition {
 		this.conditionNonCoded = conditionNonCoded;
 	}
 	
-	public Date getOnSetDate() {
+	public String getOnSetDate() {
 		return onSetDate;
 	}
 	
-	public void setOnSetDate(Date onSetDate) {
+	public void setOnSetDate(String onSetDate) {
 		this.onSetDate = onSetDate;
 	}
 	
-	public Date getEndDate() {
+	public String getEndDate() {
 		return endDate;
 	}
 	
-	public void setEndDate(Date endDate) {
+	public void setEndDate(String endDate) {
 		this.endDate = endDate;
 	}
 	

--- a/condition-list/src/main/java/org/openmrs/module/emrapi/conditionslist/contract/ConditionMapper.java
+++ b/condition-list/src/main/java/org/openmrs/module/emrapi/conditionslist/contract/ConditionMapper.java
@@ -7,6 +7,8 @@ import org.openmrs.ConceptName;
 import org.openmrs.Patient;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.emrapi.conditionslist.ConditionListConstants;
+import org.openmrs.module.emrapi.conditionslist.DateConverter;
+
 import java.util.Locale;
 
 public class ConditionMapper {
@@ -20,10 +22,10 @@ public class ConditionMapper {
 		condition.setConcept(concept);
 		condition.setPatientUuid(openmrsCondition.getPatient().getUuid());
 		condition.setConditionNonCoded(openmrsCondition.getConditionNonCoded());
-		condition.setOnSetDate(openmrsCondition.getOnsetDate());
+		condition.setOnSetDate(DateConverter.serialize(openmrsCondition.getOnsetDate()));
 		condition.setVoided(openmrsCondition.getVoided());
 		condition.setVoidReason(openmrsCondition.getVoidReason());
-		condition.setEndDate(openmrsCondition.getEndDate());
+		condition.setEndDate(DateConverter.serialize(openmrsCondition.getEndDate()));
 		condition.setCreator(openmrsCondition.getCreator().getDisplayString());
 		condition.setDateCreated(openmrsCondition.getDateCreated());
 		if (openmrsCondition.getPreviousCondition() != null) {
@@ -59,8 +61,8 @@ public class ConditionMapper {
 		openmrsCondition.setConcept(concept);
 		openmrsCondition.setPatient(patient);
 		openmrsCondition.setConditionNonCoded(condition.getConditionNonCoded());
-		openmrsCondition.setOnsetDate(condition.getOnSetDate());
-		openmrsCondition.setEndDate(condition.getEndDate());
+		openmrsCondition.setOnsetDate(DateConverter.deserialize(condition.getOnSetDate()));
+		openmrsCondition.setEndDate(DateConverter.deserialize(condition.getEndDate()));
 		openmrsCondition.setVoided(condition.getVoided());
 		openmrsCondition.setVoidReason(condition.getVoidReason());
 		

--- a/condition-list/src/test/java/org/openmrs/module/emrapi/conditionslist/contract/ConditionMapperTest.java
+++ b/condition-list/src/test/java/org/openmrs/module/emrapi/conditionslist/contract/ConditionMapperTest.java
@@ -21,6 +21,7 @@ import org.openmrs.api.ConceptService;
 import org.openmrs.api.PatientService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.emrapi.conditionslist.ConditionListConstants;
+import org.openmrs.module.emrapi.conditionslist.DateConverter;
 import org.openmrs.util.LocaleUtility;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -103,7 +104,7 @@ public class ConditionMapperTest {
 		assertEquals(conceptUuid, condition.getConcept().getUuid());
 		assertEquals(patientUuid, condition.getPatientUuid());
 		assertEquals(openmrsCondition.getDateCreated(), condition.getDateCreated());
-		assertEquals(today, condition.getOnSetDate());
+		assertEquals(today, DateConverter.deserialize(condition.getOnSetDate()));
 		assertEquals(additionalDetail, condition.getAdditionalDetail());
 		
 		assertEquals(null, condition.getEndDate());
@@ -123,14 +124,14 @@ public class ConditionMapperTest {
 		String endReasonUuid = "end-reason-uuid-288a-asdf";
 		
 		Condition condition = new Condition();
-		condition.setOnSetDate(today);
+		condition.setOnSetDate(DateConverter.serialize(today));
 		condition.setUuid(uuid);
 		
 		Concept concept = new Concept();
 		Concept endReason = new Concept();
 		endReason.setUuid(endReasonUuid);
 		condition.setEndReason(new org.openmrs.module.emrapi.conditionslist.contract.Concept(endReasonUuid, "somename"));
-		condition.setEndDate(today);
+		condition.setEndDate(DateConverter.serialize(today));
 		
 		concept.setUuid(conceptUuid);
 		Patient patient = new Patient();

--- a/web-2.2/src/main/java/org/openmrs/module/emrapi/web/controller/ConditionController.java
+++ b/web-2.2/src/main/java/org/openmrs/module/emrapi/web/controller/ConditionController.java
@@ -1,15 +1,5 @@
 package org.openmrs.module.emrapi.web.controller;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.openmrs.util.LocaleUtility.getDefaultLocale;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Locale;
-
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.CodedOrFreeText;
 import org.openmrs.Concept;
@@ -23,6 +13,7 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.emrapi.conditionslist.Condition;
 import org.openmrs.module.emrapi.conditionslist.ConditionHistory;
 import org.openmrs.module.emrapi.conditionslist.ConditionListConstants;
+import org.openmrs.module.emrapi.conditionslist.DateConverter;
 import org.openmrs.module.emrapi.conditionslist.contract.ConditionHistoryMapper;
 import org.openmrs.module.emrapi.conditionslist.contract.ConditionMapper;
 import org.openmrs.module.webservices.rest.web.v1_0.controller.BaseRestController;
@@ -33,6 +24,16 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.openmrs.util.LocaleUtility.getDefaultLocale;
 
 /**
  * This class specifies data manipulation methods on a Condition.
@@ -292,8 +293,8 @@ public class ConditionController extends BaseRestController {
 		openmrsCondition.setClinicalStatus(convertConditionListStatus(condition.getStatus()));
 		openmrsCondition.setCondition(codedOrFreeText);
 		openmrsCondition.setPatient(patient);
-		openmrsCondition.setOnsetDate(condition.getOnSetDate());
-		openmrsCondition.setEndDate(condition.getEndDate());
+		openmrsCondition.setOnsetDate(DateConverter.deserialize(condition.getOnSetDate()));
+		openmrsCondition.setEndDate(DateConverter.deserialize(condition.getEndDate()));
 		openmrsCondition.setVoided(condition.getVoided());
 		openmrsCondition.setVoidReason(condition.getVoidReason());
 
@@ -322,10 +323,10 @@ public class ConditionController extends BaseRestController {
 		contractCondition.setConcept(concept);
 		contractCondition.setPatientUuid(coreCondition.getPatient().getUuid());
 		contractCondition.setConditionNonCoded(codedOrFreeText.getNonCoded());
-		contractCondition.setOnSetDate(coreCondition.getOnsetDate());
+		contractCondition.setOnSetDate(DateConverter.serialize(coreCondition.getOnsetDate()));
 		contractCondition.setVoided(coreCondition.getVoided());
 		contractCondition.setVoidReason(coreCondition.getVoidReason());
-		contractCondition.setEndDate(coreCondition.getEndDate());
+		contractCondition.setEndDate(DateConverter.serialize(coreCondition.getEndDate()));
 		contractCondition.setCreator(coreCondition.getCreator().getUuid());
 		contractCondition.setDateCreated(coreCondition.getDateCreated());
 		if (coreCondition.getPreviousVersion() != null) {


### PR DESCRIPTION
…e server endpoint

This PR changes the model object that is used to handle the JSON representation of a condition such that the onSet and endDate properties are Strings and not Dates.  This ensures that there is no String->Date conversion happening in the Spring/Jackson internals, as I have as of yet been unsuccessful in trying to configure that to work as I'd expect.  Instead, this moves the Date conversion into a separate step that happens when this contract Condition is converted into an actual Condition.  This allows us full control over the Date conversion process.