### PR TITLE
RA-1714:Primary Diagnosis not being showed in the Encounter details

### DIFF
--- a/api-2.2/src/main/java/org/openmrs/module/emrapi/diagnosis/DiagnosisServiceImpl2_2.java
+++ b/api-2.2/src/main/java/org/openmrs/module/emrapi/diagnosis/DiagnosisServiceImpl2_2.java
@@ -1,7 +1,5 @@
 package org.openmrs.module.emrapi.diagnosis;
 
-import org.openmrs.CodedOrFreeText;
-import org.openmrs.ConditionVerificationStatus;
 import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.Patient;
@@ -9,7 +7,6 @@ import org.openmrs.api.AdministrationService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.emrapi.EmrApiConstants;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 /**
@@ -23,29 +20,13 @@ public class DiagnosisServiceImpl2_2 extends DiagnosisServiceImpl implements Dia
 		this.adminService = adminService;
 	}
 
-	/**
-	 * Method to convert the core diagnosis object into a list of diagnoses compatible with the diagnosis object in the emrapi module
-	 * @return diagnoses
-	 * */
-	private List<Diagnosis> convert(List<org.openmrs.Diagnosis> coreDiagnoses) {
-		List<Diagnosis> diagnoses = new ArrayList<Diagnosis>();
-		for (org.openmrs.Diagnosis coreDiagnosis : coreDiagnoses) {
-			Diagnosis diagnosis = new Diagnosis();
-			CodedOrFreeText coded = coreDiagnosis.getDiagnosis();
-			diagnosis.setDiagnosis(new CodedOrFreeTextAnswer(coded.getCoded(), coded.getSpecificName(), coded.getNonCoded()));
-			diagnosis.setCertainty(coreDiagnosis.getCertainty() == ConditionVerificationStatus.CONFIRMED ? Diagnosis.Certainty.CONFIRMED : Diagnosis.Certainty.PRESUMED);
-			diagnosis.setOrder(coreDiagnosis.getRank() == 1 ? Diagnosis.Order.PRIMARY : Diagnosis.Order.SECONDARY);
-			diagnoses.add(diagnosis);
-		}
-		return diagnoses;
-	}
 
 	public List<Diagnosis> getDiagnoses(Patient patient, Date fromDate) {
 		if (adminService.getGlobalProperty(EmrApiConstants.GP_USE_LEGACY_DIAGNOSIS_SERVICE,"false").equalsIgnoreCase("true")) {
 			return super.getDiagnoses(patient,fromDate);
 		}
 		 else {
-			return convert(Context.getDiagnosisService().getDiagnoses(patient, fromDate));
+			return DiagnosisUtils.convert(Context.getDiagnosisService().getDiagnoses(patient, fromDate));
 		}
 	}
 
@@ -55,7 +36,7 @@ public class DiagnosisServiceImpl2_2 extends DiagnosisServiceImpl implements Dia
 			return super.getUniqueDiagnoses(patient, fromDate);
 		}
 		else {
-			return convert(Context.getDiagnosisService().getUniqueDiagnoses(patient, fromDate));
+			return DiagnosisUtils.convert(Context.getDiagnosisService().getUniqueDiagnoses(patient, fromDate));
 		}
 
 	}
@@ -65,7 +46,7 @@ public class DiagnosisServiceImpl2_2 extends DiagnosisServiceImpl implements Dia
 			return super.getPrimaryDiagnoses(encounter);
 		}
 		else {
-			return convert(Context.getDiagnosisService().getPrimaryDiagnoses(encounter));
+			return DiagnosisUtils.convert(Context.getDiagnosisService().getPrimaryDiagnoses(encounter));
 		}
 	}
 

--- a/api-2.2/src/main/java/org/openmrs/module/emrapi/diagnosis/DiagnosisUtils.java
+++ b/api-2.2/src/main/java/org/openmrs/module/emrapi/diagnosis/DiagnosisUtils.java
@@ -1,0 +1,28 @@
+package org.openmrs.module.emrapi.diagnosis;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.openmrs.CodedOrFreeText;
+import org.openmrs.ConditionVerificationStatus;
+
+public class DiagnosisUtils {
+
+    /**
+     * Method to convert the core diagnosis object into a list of diagnoses compatible with the diagnosis object in the emrapi module
+     * @return diagnoses
+     * */
+    public static List<Diagnosis> convert(List<org.openmrs.Diagnosis> coreDiagnoses) {
+        List<Diagnosis> diagnoses = new ArrayList<Diagnosis>();
+        for (Object coreDiagnosis2 : coreDiagnoses) {
+            org.openmrs.Diagnosis coreDiagnosis = (org.openmrs.Diagnosis)coreDiagnosis2;
+            Diagnosis diagnosis = new Diagnosis();
+            CodedOrFreeText coded = coreDiagnosis.getDiagnosis();
+            diagnosis.setDiagnosis(new CodedOrFreeTextAnswer(coded.getCoded(), coded.getSpecificName(), coded.getNonCoded()));
+            diagnosis.setCertainty(coreDiagnosis.getCertainty() == ConditionVerificationStatus.CONFIRMED ? Diagnosis.Certainty.CONFIRMED : Diagnosis.Certainty.PRESUMED);
+            diagnosis.setOrder(coreDiagnosis.getRank() == 1 ? Diagnosis.Order.PRIMARY : Diagnosis.Order.SECONDARY);
+            diagnoses.add(diagnosis);
+        }
+        return diagnoses;
+    }
+}

--- a/api-2.2/src/main/java/org/openmrs/module/emrapi/diagnosis/EmrDiagnosisDAO.java
+++ b/api-2.2/src/main/java/org/openmrs/module/emrapi/diagnosis/EmrDiagnosisDAO.java
@@ -1,0 +1,10 @@
+package org.openmrs.module.emrapi.diagnosis;
+
+import org.openmrs.Visit;
+
+import java.util.List;
+
+public interface EmrDiagnosisDAO {
+
+    List<org.openmrs.Diagnosis> getDiagnoses(Visit visit, boolean primaryOnly, boolean confirmedOnly);
+}

--- a/api-2.2/src/main/java/org/openmrs/module/emrapi/diagnosis/EmrDiagnosisDAOImpl2_2.java
+++ b/api-2.2/src/main/java/org/openmrs/module/emrapi/diagnosis/EmrDiagnosisDAOImpl2_2.java
@@ -1,0 +1,56 @@
+package org.openmrs.module.emrapi.diagnosis;
+
+import org.hibernate.Query;
+import org.openmrs.Visit;
+import org.openmrs.api.db.hibernate.DbSessionFactory;
+
+import java.util.List;
+
+/**
+ * Hibernate implementation of the EmrDiagnosisDAO
+ */
+public class EmrDiagnosisDAOImpl2_2 implements EmrDiagnosisDAO {
+
+   // TODO: Fetching diagnosis should be delegated to core Diagnosis service.
+   // https://issues.openmrs.org/browse/TRUNK-5999
+
+   private static final Integer PRIMARY_RANK = 1;
+
+   private static final String CONFIRMED_CERTAINTY = "CONFIRMED";
+
+   private DbSessionFactory sessionFactory;
+
+   public void setSessionFactory(DbSessionFactory sessionFactory) {
+      this.sessionFactory = sessionFactory;
+   }
+
+   /**
+    * Gets the diagnosis for a given visit
+    *
+    * @param visit visit to get the diagnoses from
+    * @param primaryOnly whether to fetch primary diagnosis only or all diagnosis regardless of rank
+    * @param confirmedOnly whether to fetch only confirmed diagnosis or both confirmed and provisional
+    * @return list of diagnoses for a visit
+    */
+   public List<org.openmrs.Diagnosis> getDiagnoses(Visit visit, boolean primaryOnly, boolean confirmedOnly) {
+      String queryString = "from Diagnosis d where d.encounter.visit.visitId = :visitId and d.voided = false";
+      if (primaryOnly == true) {
+         queryString += " and d.rank = :rankId";
+      }
+      if (confirmedOnly == true) {
+         queryString += " and d.certainty = :certainty";
+      }
+      queryString += " order by d.dateCreated desc";
+
+      Query query = sessionFactory.getCurrentSession().createQuery(queryString);
+      query.setInteger("visitId", visit.getId());
+      if (primaryOnly == true) {
+         query.setInteger("rankId", PRIMARY_RANK);
+      }
+      if (confirmedOnly == true) {
+         query.setString("certainty", CONFIRMED_CERTAINTY);
+      }
+
+      return (List<org.openmrs.Diagnosis>) query.list();
+   }
+}

--- a/api-2.2/src/main/java/org/openmrs/module/emrapi/visit/EmrVisitServiceImpl2_2.java
+++ b/api-2.2/src/main/java/org/openmrs/module/emrapi/visit/EmrVisitServiceImpl2_2.java
@@ -1,0 +1,46 @@
+package org.openmrs.module.emrapi.visit;
+
+import org.openmrs.Obs;
+import org.openmrs.Visit;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.api.VisitService;
+import org.openmrs.module.emrapi.EmrApiConstants;
+import org.openmrs.module.emrapi.diagnosis.Diagnosis;
+import org.openmrs.module.emrapi.diagnosis.DiagnosisMetadata;
+import org.openmrs.module.emrapi.diagnosis.DiagnosisUtils;
+import org.openmrs.module.emrapi.diagnosis.EmrDiagnosisDAO;
+import java.util.ArrayList;
+import java.util.List;
+
+public class EmrVisitServiceImpl2_2 extends EmrVisitServiceImpl implements EmrVisitService {
+
+	private AdministrationService adminService;
+
+	private EmrDiagnosisDAO emrDiagnosisDAO;
+
+	public void setAdminService(AdministrationService adminService) {
+		this.adminService = adminService;
+	}
+
+	public void setEmrDiagnosisDAO(EmrDiagnosisDAO emrDiagnosisDAO) {
+		this.emrDiagnosisDAO = emrDiagnosisDAO;
+	}
+
+	public EmrVisitServiceImpl2_2(VisitService visitService, VisitResponseMapper visitResponseMapper) {
+		super(visitService, visitResponseMapper);
+	}
+
+	@Override
+	public List<Obs> getDiagnoses(Visit visit, DiagnosisMetadata diagnosisMetadata, Boolean primaryOnly, Boolean confirmedOnly) {
+		if (adminService.getGlobalProperty(EmrApiConstants.GP_USE_LEGACY_DIAGNOSIS_SERVICE, "false").equalsIgnoreCase("true")) {
+			return super.getDiagnoses(visit, diagnosisMetadata, primaryOnly, confirmedOnly);
+		} else {
+			List<org.openmrs.Diagnosis> diagnoses = emrDiagnosisDAO.getDiagnoses(visit, primaryOnly, confirmedOnly);
+			List<Obs> diagnosisList = new ArrayList<Obs>();
+			for (Diagnosis diagnosis : DiagnosisUtils.convert(diagnoses)) {
+				diagnosisList.add(diagnosisMetadata.buildDiagnosisObsGroup(diagnosis));
+			}
+			return diagnosisList;
+		}
+	}
+}

--- a/api-2.2/src/main/resources/moduleApplicationContext.xml
+++ b/api-2.2/src/main/resources/moduleApplicationContext.xml
@@ -33,4 +33,19 @@
 		</property>
 	</bean>
 
+
+	<bean id="emrDiagnosisDAO" class="org.openmrs.module.emrapi.diagnosis.EmrDiagnosisDAOImpl2_2">
+		<property name="sessionFactory"><ref bean="dbSessionFactory"/></property>
+	</bean>
+
+	<bean id="emrVisitServiceImpl" class="${project.parent.groupId}.${project.parent.artifactId}.visit.EmrVisitServiceImpl2_2">
+		<constructor-arg ref="visitService"/>
+		<constructor-arg ref="visitResponseMapper"/>
+		<property name="dao">
+			<ref bean="emrVisitDAOImpl"/>
+		</property>
+		<property name="adminService" ref="adminService"/>
+		<property name="emrDiagnosisDAO" ref="emrDiagnosisDAO"/>
+	</bean>
+
 </beans>

--- a/api-2.2/src/test/java/org/openmrs/emrapi/diagnosis/EmrDiagnosisDAOTest.java
+++ b/api-2.2/src/test/java/org/openmrs/emrapi/diagnosis/EmrDiagnosisDAOTest.java
@@ -1,0 +1,65 @@
+package org.openmrs.emrapi.diagnosis;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openmrs.ConditionVerificationStatus;
+import org.openmrs.Visit;
+import org.openmrs.module.emrapi.diagnosis.EmrDiagnosisDAO;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import java.util.List;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class EmrDiagnosisDAOTest extends BaseModuleContextSensitiveTest {
+
+    private static final String DIAGNOSIS_DATASET = "DiagnosisDataset.xml";
+
+    @Autowired
+    private EmrDiagnosisDAO emrDiagnosisDAO;
+
+    private Visit visit = mock(Visit.class);
+
+    @Before
+    public void setUp() throws Exception {
+        executeDataSet(DIAGNOSIS_DATASET);
+        when(visit.getId()).thenReturn(1010);
+    }
+
+    @Test
+    public void shouldReturnAllNonVoidedDiagnosesFromVisit() {
+        List<org.openmrs.Diagnosis> diagnoses = emrDiagnosisDAO.getDiagnoses(visit, false, false);
+        assertEquals(4, diagnoses.size());
+        assertEquals(Boolean.FALSE, diagnoses.get(0).getVoided());
+        assertEquals(Boolean.FALSE, diagnoses.get(1).getVoided());
+        assertEquals(Boolean.FALSE, diagnoses.get(2).getVoided());
+        assertEquals(Boolean.FALSE, diagnoses.get(3).getVoided());
+    }
+
+    @Test
+    public void shouldReturnAllPrimaryConfirmedDiagnosesFromVisit() {
+        List<org.openmrs.Diagnosis> diagnoses = emrDiagnosisDAO.getDiagnoses(visit, true, true);
+        assertEquals(1, diagnoses.size());
+        assertEquals(ConditionVerificationStatus.CONFIRMED, diagnoses.get(0).getCertainty());
+    }
+
+    @Test
+    public void shouldReturnAllPrimaryDiagnosesFromVisit() {
+        List<org.openmrs.Diagnosis> diagnoses = emrDiagnosisDAO.getDiagnoses(visit, true, false);
+        assertEquals(2, diagnoses.size());
+        assertEquals(new Integer(1), diagnoses.get(0).getRank());
+        assertEquals(new Integer(1), diagnoses.get(1).getRank());
+    }
+
+    @Test
+    public void shouldReturnAllConfirmedDiagnosesFromVisit() {
+        List<org.openmrs.Diagnosis> diagnoses = emrDiagnosisDAO.getDiagnoses(visit, false, true);
+        assertEquals(2, diagnoses.size());
+        assertEquals(ConditionVerificationStatus.CONFIRMED, diagnoses.get(0).getCertainty());
+        assertEquals(ConditionVerificationStatus.CONFIRMED, diagnoses.get(1).getCertainty());
+    }
+}

--- a/api-2.2/src/test/resources/DiagnosisDataset.xml
+++ b/api-2.2/src/test/resources/DiagnosisDataset.xml
@@ -26,4 +26,12 @@
 	<obs obs_id="3" person_id="7" concept_id="159394" encounter_id="1" obs_datetime="2018-05-03 17:47:04.0" location_id="3" obs_group_id="1" value_coded="159393" creator="1" date_created="2018-05-03 17:47:04.0" voided="false" uuid="df4358f3-3070-47b9-bb5c-ff36ed112d51" status="FINAL"/>
 	<obs obs_id="4" person_id="7" concept_id="1284" encounter_id="1" obs_datetime="2018-05-03 17:47:04.0" location_id="3" obs_group_id="1" value_coded="116128" value_coded_name_id="16603" creator="1" date_created="2018-05-03 17:47:04.0" voided="false" uuid="89f02814-2c50-48ae-bca4-4b4709d42486" status="FINAL"/>
 	<obs obs_id="5" person_id="9" concept_id="159965" encounter_id="1" obs_datetime="2018-05-03 17:47:04.0" location_id="3" obs_group_id="1" value_coded="159393" creator="1" date_created="2018-05-03 17:47:04.0" voided="false" uuid="df4358f3-3070-47b9-bb5c-jhvj34Y51" status="FINAL"/>
+
+	<encounter_diagnosis diagnosis_id="1" encounter_id="1" patient_id="2" creator="1" date_created="2017-01-12 00:00:00" rank="1" certainty="CONFIRMED" voided="false" uuid="7a14b71c-df9b-41d2-ba2a-7c20250161fa"/>
+	<encounter_diagnosis diagnosis_id="2" encounter_id="1" patient_id="2" creator="1" date_created="2016-01-12 00:00:00" rank="1" certainty="PROVISIONAL" voided="false" uuid="a3650f2a-f511-4642-9895-fe26876659ca"/>
+	<encounter_diagnosis diagnosis_id="3" encounter_id="1" patient_id="2" creator="1" date_created="2016-01-12 00:00:00" rank="1" certainty="PROVISIONAL" voided="true" date_voided="2017-01-12 00:00:52" voided_by="1" void_reason="test reason" uuid="ab26abdc-e62d-4adc-9f7d-6a80e8e48cc7"/>
+	<encounter_diagnosis diagnosis_id="4" encounter_id="1" patient_id="2" creator="1" date_created="2017-01-12 00:00:00" rank="2" certainty="CONFIRMED" voided="false" uuid="1c012502-c9f0-4839-b897-791cf9ad2910"/>
+	<encounter_diagnosis diagnosis_id="5" encounter_id="1" patient_id="2" creator="1" date_created="2016-01-12 00:00:00" rank="2" certainty="PROVISIONAL" voided="false" uuid="c033f9c4-a605-4613-972f-22f045db6bc7"/>
+	<encounter_diagnosis diagnosis_id="6" encounter_id="1" patient_id="2" creator="1" date_created="2016-01-12 00:00:00" rank="2" certainty="PROVISIONAL" voided="true" date_voided="2017-01-12 00:00:52" voided_by="1" void_reason="test reason" uuid="52c70212-66e9-4fb9-be92-75805971c2aa"/>
+	
 </dataset>

--- a/api-pre2.2/src/main/resources/moduleApplicationContext.xml
+++ b/api-pre2.2/src/main/resources/moduleApplicationContext.xml
@@ -32,4 +32,12 @@
 		</property>
 	</bean>
 
+	<bean id="emrVisitServiceImpl" class="${project.parent.groupId}.${project.parent.artifactId}.visit.EmrVisitServiceImpl">
+        <constructor-arg ref="visitService"/>
+        <constructor-arg ref="visitResponseMapper"/>
+        <property name="dao">
+            <ref bean="emrVisitDAOImpl"/>
+        </property>
+    </bean>
+
 </beans>

--- a/api/src/main/resources/hql/patients_diagnoses.hql
+++ b/api/src/main/resources/hql/patients_diagnoses.hql
@@ -3,7 +3,7 @@ select
 from
   Patient p
 where
-    p.voided = 0
+    p.voided = 'false'
     and p.patientId in(select distinct personId from Obs o
     where
         o.concept.conceptId = :diagnosisSetConceptId

--- a/api/src/main/resources/hql/visit_primary_diagnoses.hql
+++ b/api/src/main/resources/hql/visit_primary_diagnoses.hql
@@ -1,7 +1,5 @@
-select
-  o.obsGroup
-from
-  Obs o
+select o1 from Obs o
+inner join o.obsGroup o1	
 where
   o.voided = 'false'
   and (o.encounter.visit = :visitId)

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -239,20 +239,12 @@
         </property>
     </bean>
 
-    <bean id="emrVisitServiceImpl" class="${project.parent.groupId}.${project.parent.artifactId}.visit.EmrVisitServiceImpl">
-        <constructor-arg ref="visitService"/>
-        <constructor-arg ref="visitResponseMapper"/>
-        <property name="dao">
-            <ref local="emrVisitDAOImpl"/>
-        </property>
-    </bean>
-
     <bean id="emrVisitService" class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
         <property name="transactionManager">
             <ref bean="transactionManager"/>
         </property>
         <property name="target">
-            <ref local="emrVisitServiceImpl"/>
+            <ref bean="emrVisitServiceImpl"/>
         </property>
         <property name="preInterceptors">
             <ref bean="serviceInterceptors"/>


### PR DESCRIPTION
Ticket: RA-1714

This pull request addresses the issues of RA-1714:Primary Diagnosis not being showed in the Encounter details , which are part of the affected Version tag 1.28.0 openmrs-module-emrapi.

Description:

Created EmrDiagnosisDAO to fetch core diagnosis entities using HQL query.

Created EmrVisitServiceImpl2_2 that uses new EmrDiagnosisDAO and extends previously existing EmrVisitServiceImpl.

EmrVisitServiceImpl2_2 supports both legacy diagnosis obs and new diagnosis entities based on emrapi.useLegacyDiagnosisService global property configuration.

