### PR TITLE
EA-180 | Unable to save dosing instruction route in user locale. Test fix

### DIFF
--- a/api-1.12/src/test/java/org/openmrs/module/emrapi/encounter/mapper/DosingInstructionsMapperTest.java
+++ b/api-1.12/src/test/java/org/openmrs/module/emrapi/encounter/mapper/DosingInstructionsMapperTest.java
@@ -48,7 +48,7 @@ public class DosingInstructionsMapperTest {
         Concept capsuleConcept = new Concept();
         when(orderMetadataService.getDoseUnitsConceptByName(dosingInstructions.getDoseUnits())).thenReturn(capsuleConcept);
         Concept routeConcept = new Concept();
-        when(conceptService.getConceptByName(dosingInstructions.getRoute())).thenReturn(routeConcept);
+        when(orderMetadataService.getRouteConceptByName(dosingInstructions.getRoute())).thenReturn(routeConcept);
         Concept frequencyConcept = new Concept();
         when(conceptService.getConceptByName(dosingInstructions.getFrequency())).thenReturn(frequencyConcept);
         OrderFrequency orderFrequency = new OrderFrequency();


### PR DESCRIPTION
Fixed the failing test of dosingInstructionMapper class