### PR TITLE
Upgrade testdatamanager and ensures test data follows correct modelin…

### DIFF
--- a/api/src/test/java/org/openmrs/module/emrapi/adt/reporting/evaluator/AwaitingAdmissionVisitQueryEvaluatorTest.java
+++ b/api/src/test/java/org/openmrs/module/emrapi/adt/reporting/evaluator/AwaitingAdmissionVisitQueryEvaluatorTest.java
@@ -462,12 +462,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter3)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter3, admitToHospital);
 
         VisitQueryResult result = visitQueryService.evaluate(query, null);
         assertThat(result.getMemberIds().size(), is(1));

--- a/api/src/test/java/org/openmrs/module/emrapi/adt/reporting/evaluator/AwaitingAdmissionVisitQueryEvaluatorTest.java
+++ b/api/src/test/java/org/openmrs/module/emrapi/adt/reporting/evaluator/AwaitingAdmissionVisitQueryEvaluatorTest.java
@@ -11,8 +11,8 @@ import org.openmrs.Obs;
 import org.openmrs.Patient;
 import org.openmrs.Visit;
 import org.openmrs.api.ConceptService;
-import org.openmrs.api.PatientService;
 import org.openmrs.contrib.testdata.TestDataManager;
+import org.openmrs.contrib.testdata.builder.ObsBuilder;
 import org.openmrs.module.emrapi.EmrApiConstants;
 import org.openmrs.module.emrapi.EmrApiProperties;
 import org.openmrs.module.emrapi.adt.reporting.query.AwaitingAdmissionVisitQuery;
@@ -72,6 +72,12 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
         patient = testDataManager.randomPatient().birthdate("2010-01-01").save();
     }
 
+    private Obs createDispositionObs(Encounter encounter, Concept disposition) {
+        ObsBuilder groupBuilder = testDataManager.obs().encounter(encounter).concept(dispositionDescriptor.getDispositionSetConcept());
+        groupBuilder.member(testDataManager.obs().encounter(encounter).concept(dispositionDescriptor.getDispositionConcept()).value(disposition).get());
+        return groupBuilder.save();
+    }
+
     @Test
     public void shouldFindVisitAwaitingAdmission() throws Exception {
 
@@ -88,12 +94,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        Obs obs = testDataManager.obs()
-                .person(patient)
-                .encounter(encounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(encounter, admitToHospital);
 
         VisitQueryResult result = visitQueryService.evaluate(query, null);
         assertThat(result.getMemberIds().size(), is(1));
@@ -120,12 +121,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .dateVoided(new Date())
                 .voidReason("test")
                 .save();
-        Obs obs = testDataManager.obs()
-                .person(patient)
-                .encounter(encounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(encounter, admitToHospital);
 
         VisitQueryResult result = visitQueryService.evaluate(query, null);
         assertThat(result.getMemberIds().size(), is(0));
@@ -151,12 +147,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter, admitToHospital);
         Encounter admissionEncounter = testDataManager.encounter()
                 .patient(patient)
                 .encounterDatetime(admitDatetime)
@@ -187,12 +178,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter, admitToHospital);
         Encounter admissionEncounter = testDataManager.encounter()
                 .patient(patient)
                 .encounterDatetime(admitDatetime)
@@ -227,12 +213,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter, admitToHospital);
         Encounter secondVisitNoteEncounter = testDataManager.encounter()
                 .patient(patient)
                 .encounterDatetime(secondVisitNoteDatetime)
@@ -269,12 +250,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(emrConceptService.getConcept("org.openmrs.module.emrapi:Death"))
-                .save();
+        createDispositionObs(visitNoteEncounter, emrConceptService.getConcept("org.openmrs.module.emrapi:Death"));
 
         VisitQueryResult result = visitQueryService.evaluate(query, null);
         assertThat(result.getMemberIds().size(), is(0));
@@ -301,12 +277,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter, admitToHospital);
 
         query.setLocation(queryLocation);
         VisitQueryResult result = visitQueryService.evaluate(query, null);
@@ -333,12 +304,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter, admitToHospital);
 
         query.setLocation(queryLocation);
         VisitQueryResult result = visitQueryService.evaluate(query, null);
@@ -361,12 +327,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter, admitToHospital);
         Encounter visitNoteEncounter2 = testDataManager.encounter()
                 .patient(patient)
                 .encounterDatetime(new Date())
@@ -401,12 +362,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter, admitToHospital);
 
         EvaluationContext context = new EvaluationContext();
         context.setBaseCohort(new Cohort(Collections.singleton(2)));
@@ -430,12 +386,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter, admitToHospital);
 
         VisitEvaluationContext context = new VisitEvaluationContext();
         context.setBaseVisits(new VisitIdSet(10101));  // random visit id
@@ -459,12 +410,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter, admitToHospital);
         Encounter visitNoteEncounter2 = testDataManager.encounter()
                 .patient(patient)
                 .encounterDatetime(new DateTime(2014,10,10,11,0,0).toDate())
@@ -497,12 +443,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter, admitToHospital);
         Encounter visitNoteEncounter2 = testDataManager.encounter()
                 .patient(patient)
                 .encounterDatetime(new DateTime(2014,10,10,11,0,0).toDate())
@@ -548,12 +489,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter, admitToHospital);
         Encounter visitNoteEncounter2 = testDataManager.encounter()
                 .patient(patient)
                 .encounterDatetime(new DateTime(2014,10,10,11,0,0).toDate())
@@ -572,12 +508,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter3)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter3, admitToHospital);
         Encounter visitNoteEncounter4 = testDataManager.encounter()
                 .patient(patient)
                 .encounterDatetime(new DateTime(2014,10,10,13,0,0).toDate())
@@ -610,12 +541,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter, admitToHospital);
         Encounter visitNoteEncounter2 = testDataManager.encounter()
                 .patient(patient)
                 .encounterDatetime(new DateTime(2014,10,10,11,0,0).toDate())
@@ -649,12 +575,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter, admitToHospital);
         Encounter visitNoteEncounter2 = testDataManager.encounter()
                 .patient(patient)
                 .encounterDatetime(new DateTime(2014,10,9,10,0,0).toDate())
@@ -688,12 +609,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter, admitToHospital);
         Encounter visitNoteEncounter2 = testDataManager.encounter()
                 .patient(patient)
                 .encounterDatetime(new DateTime(2014,10,11,10,0,0).toDate())
@@ -736,12 +652,7 @@ public class AwaitingAdmissionVisitQueryEvaluatorTest extends BaseModuleContextS
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
                 .visit(visit)
                 .save();
-        testDataManager.obs()
-                .person(patient)
-                .encounter(visitNoteEncounter)
-                .concept(dispositionDescriptor.getDispositionConcept())
-                .value(admitToHospital)
-                .save();
+        createDispositionObs(visitNoteEncounter, admitToHospital);
 
         VisitQueryResult result = visitQueryService.evaluate(query, null);
         assertThat(result.getMemberIds().size(), is(0));

--- a/api/src/test/java/org/openmrs/module/emrapi/visit/VisitDomainWrapperComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/emrapi/visit/VisitDomainWrapperComponentTest.java
@@ -4,6 +4,7 @@ import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.openmrs.Concept;
 import org.openmrs.Encounter;
 import org.openmrs.EncounterType;
 import org.openmrs.Location;
@@ -14,6 +15,7 @@ import org.openmrs.api.ConceptService;
 import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
 import org.openmrs.contrib.testdata.TestDataManager;
+import org.openmrs.contrib.testdata.builder.ObsBuilder;
 import org.openmrs.module.emrapi.EmrApiConstants;
 import org.openmrs.module.emrapi.EmrApiProperties;
 import org.openmrs.module.emrapi.concept.EmrConceptService;
@@ -76,6 +78,12 @@ public class VisitDomainWrapperComponentTest extends BaseModuleContextSensitiveT
         Context.flushSession();
     }
 
+    private Obs createDispositionObs(Encounter encounter, Concept disposition) {
+        ObsBuilder groupBuilder = testDataManager.obs().encounter(encounter).concept(dispositionDescriptor.getDispositionSetConcept());
+        groupBuilder.member(testDataManager.obs().encounter(encounter).concept(dispositionDescriptor.getDispositionConcept()).value(disposition).get());
+        return groupBuilder.save();
+    }
+
     @Test
     public void testThatBeanCanHavePropertiesAutowired() throws Exception {
         VisitDomainWrapper visitDomainWrapper = factory.newVisitDomainWrapper();
@@ -102,11 +110,8 @@ public class VisitDomainWrapperComponentTest extends BaseModuleContextSensitiveT
                 .visit(visit)
                 .encounterDatetime(new Date())
                 .encounterType(emrApiProperties.getVisitNoteEncounterType())
-                .obs(testDataManager.obs()
-                        .concept(dispositionDescriptor.getDispositionConcept())
-                        .value(emrConceptService.getConcept("org.openmrs.module.emrapi:Admit to hospital"))
-                        .get())
                 .save();
+        createDispositionObs(encounter, emrConceptService.getConcept("org.openmrs.module.emrapi:Admit to hospital"));
 
         VisitDomainWrapper visitDomainWrapper = factory.newVisitDomainWrapper(visit);
         assertThat(visitDomainWrapper.isAwaitingAdmission(), is(true));
@@ -135,11 +140,8 @@ public class VisitDomainWrapperComponentTest extends BaseModuleContextSensitiveT
                 .voided(true)
                 .dateVoided(new Date())
                 .voidReason("test")
-                .obs(testDataManager.obs()
-                        .concept(dispositionDescriptor.getDispositionConcept())
-                        .value(emrConceptService.getConcept("org.openmrs.module.emrapi:Admit to hospital"))
-                        .get())
                 .save();
+        createDispositionObs(encounter, emrConceptService.getConcept("org.openmrs.module.emrapi:Admit to hospital"));
 
         VisitDomainWrapper visitDomainWrapper = factory.newVisitDomainWrapper(visit);
         assertThat(visitDomainWrapper.isAwaitingAdmission(), is(false));

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <openMRSVersion>2.2.1</openMRSVersion>
         <legacyuiVersion>1.16.0</legacyuiVersion>
-        <openmrsTestutilsVersion>1.7.0</openmrsTestutilsVersion>
+        <openmrsTestutilsVersion>1.8.0-SNAPSHOT</openmrsTestutilsVersion>
         <reportingVersion>1.25.0</reportingVersion>
         <serialization.xstreamVersion>0.2.16</serialization.xstreamVersion>
         <calculationVersion>1.3.0</calculationVersion>


### PR DESCRIPTION
…g for dispositions to use obs groups

This is a non-functional change.  It updates some tests that currently pass but which are based off of invalid data, which is only passing due to the specific nature of how the functionality is written.

The goal here is to ensure the test data is modeled correctly and can demonstrate that existing tests pass if the underlying implementation is updated in the future.