### PR TITLE
EA-216: Optimize diagnosis migration performance for large datasets

### DIFF
--- a/api/src/main/java/org/openmrs/module/emrapi/db/EmrApiDAO.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/db/EmrApiDAO.java
@@ -8,5 +8,9 @@ public interface EmrApiDAO {
     <T> List<T> executeHql(String queryString, Map<String, Object> parameters, Class<T> clazz);
 
     <T> List<T> executeHqlFromResource(String resource, Map<String, Object> parameters, Class<T> clazz);
+    
+    <T> List<T> executeHql(String queryString, Map<String, Object> parameters, Class<T> clazz, Integer maxResults);
+    
+    <T> List<T> executeHqlFromResource(String resource, Map<String, Object> parameters, Class<T> clazz, Integer maxResults);
 
 }

--- a/api/src/main/java/org/openmrs/module/emrapi/db/EmrApiDAO.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/db/EmrApiDAO.java
@@ -9,8 +9,8 @@ public interface EmrApiDAO {
 
     <T> List<T> executeHqlFromResource(String resource, Map<String, Object> parameters, Class<T> clazz);
     
-    <T> List<T> executeHql(String queryString, Map<String, Object> parameters, Class<T> clazz, Integer maxResults);
+    <T> List<T> executeHql(String hql, Map<String, Object> parameters, int startIndex, int pageSize);
     
-    <T> List<T> executeHqlFromResource(String resource, Map<String, Object> parameters, Class<T> clazz, Integer maxResults);
+    <T> List<T> executeHqlFromResource(String resource, Map<String, Object> parameters, int startIndex, int pageSize);
 
 }

--- a/api/src/main/java/org/openmrs/module/emrapi/diagnosis/DiagnosisMigrationException.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/diagnosis/DiagnosisMigrationException.java
@@ -1,0 +1,25 @@
+/*
+ * The contents of this file are subject to the OpenMRS Public License
+ * Version 1.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ * http://license.openmrs.org
+ *
+ * Software distributed under the License is distributed on an "AS IS"
+ * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+ * License for the specific language governing rights and limitations
+ * under the License.
+ *
+ * Copyright (C) OpenMRS, LLC.  All Rights Reserved.
+ */
+package org.openmrs.module.emrapi.diagnosis;
+
+public class DiagnosisMigrationException extends RuntimeException {
+	
+	public DiagnosisMigrationException(String message) {
+		super(message);
+	}
+    
+    public DiagnosisMigrationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/api/src/main/java/org/openmrs/module/emrapi/diagnosis/DiagnosisUtils.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/diagnosis/DiagnosisUtils.java
@@ -4,8 +4,10 @@ import org.openmrs.CodedOrFreeText;
 import org.openmrs.ConditionVerificationStatus;
 import org.openmrs.Encounter;
 import org.openmrs.Obs;
+import org.openmrs.util.PrivilegeConstants;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class DiagnosisUtils {
@@ -81,5 +83,23 @@ public class DiagnosisUtils {
         }
 
         return coreDiagnosis;
+    }
+    
+    /**
+     * Returns a list of privileges required for diagnosis migration.
+     * These privileges are used to ensure that the user has the necessary permissions
+     * to perform diagnosis migration operations.
+     *
+     * @return a list of required privileges for diagnosis migration
+     */
+    public static List<String> getRequiredPrivilegesForDiagnosisMigration() {
+        return Arrays.asList(
+                PrivilegeConstants.GET_PATIENTS, PrivilegeConstants.GET_CONCEPT_SOURCES,
+                PrivilegeConstants.GET_OBS, PrivilegeConstants.GET_CONCEPTS,
+                PrivilegeConstants.GET_DIAGNOSES, PrivilegeConstants.GET_GLOBAL_PROPERTIES,
+                PrivilegeConstants.EDIT_OBS, PrivilegeConstants.ADD_OBS,
+                PrivilegeConstants.DELETE_OBS, PrivilegeConstants.EDIT_DIAGNOSES,
+                "Add Diagnoses"
+        );
     }
 }

--- a/api/src/main/resources/hql/patients_diagnoses.hql
+++ b/api/src/main/resources/hql/patients_diagnoses.hql
@@ -7,4 +7,5 @@ where
     and p.patientId in(select distinct personId from Obs o
     where
         o.concept = :diagnosisSetConcept
+        and o.voided = 'false'
     )

--- a/api/src/test/java/org/openmrs/module/emrapi/diagnosis/ObsGroupDiagnosisServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/emrapi/diagnosis/ObsGroupDiagnosisServiceComponentTest.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -33,8 +34,13 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ObsGroupDiagnosisServiceComponentTest extends EmrApiContextSensitiveTest {
@@ -214,6 +220,25 @@ public class ObsGroupDiagnosisServiceComponentTest extends EmrApiContextSensitiv
 		assertThat(diagnoses.get(1).getDiagnosis().getCoded(), is(malaria));
 		assertThat(diagnoses.get(1).getCertainty(), is(ConditionVerificationStatus.PROVISIONAL));
 		assertThat(diagnoses.get(1).getRank(), is(2));
+	}
+	
+	@Test
+	public void getPatientsWithDiagnosis_shouldReturnPatientIds() {
+		Patient patient = patientService.getPatient(2);
+		buildDiagnosis(patient, "2025-05-29", Diagnosis.Order.PRIMARY, Diagnosis.Certainty.PRESUMED, "non-coded pain").save();
+		
+		List<Integer> patientIds = diagnosisService.getPatientsWithDiagnosis(dmd, 0, 10);
+		
+		assertThat(patientIds, is(notNullValue()));
+		assertThat(patientIds.size(), is(1));
+		assertThat(patientIds, contains(patient.getId()));
+	}
+	
+	@Test
+	public void getPatientsWithDiagnosis_shouldReturnEmptyPatientIdsList() {
+		List<Integer> patientIds = diagnosisService.getPatientsWithDiagnosis(dmd, 0, 10);
+		
+		assertThat(patientIds, is(empty()));
 	}
 
 	public static Matcher<Diagnosis> hasObs(final Obs obs) {

--- a/api/src/test/resources/DiagnosisDataset.xml
+++ b/api/src/test/resources/DiagnosisDataset.xml
@@ -34,4 +34,6 @@
 	<encounter_diagnosis diagnosis_id="5" encounter_id="1" patient_id="2" creator="1" date_created="2016-01-12 00:00:00" rank="2" certainty="PROVISIONAL" voided="false" uuid="c033f9c4-a605-4613-972f-22f045db6bc7"/>
 	<encounter_diagnosis diagnosis_id="6" encounter_id="1" patient_id="2" creator="1" date_created="2016-01-12 00:00:00" rank="2" certainty="PROVISIONAL" voided="true" date_voided="2017-01-12 00:00:52" voided_by="1" void_reason="test reason" uuid="52c70212-66e9-4fb9-be92-75805971c2aa"/>
 
+	<!-- The global property below is used to set the batch size for diagnosis migration -->
+	<global_property property="emrapi.diagnosisMigrationBatchSize" property_value="500" uuid="d4f8b0c2-3c5e-4a6b-bf9d-8f0c1e2b3c4d"/>
 </dataset>

--- a/omod/src/main/java/org/openmrs/module/emrapi/web/controller/MigrateDiagnosisController.java
+++ b/omod/src/main/java/org/openmrs/module/emrapi/web/controller/MigrateDiagnosisController.java
@@ -31,7 +31,7 @@ public class MigrateDiagnosisController {
 	public String doEncounterDiagnosisMigration(HttpSession session, HttpServletRequest request) {
 		DiagnosisMetadata diagnosisMetadata = emrApiProps.getDiagnosisMetadata();
 		if (ModuleUtil.compareVersion(OpenmrsConstants.OPENMRS_VERSION, "2.2.0") >= 0) {
-			if (new MigrateDiagnosis().migrate(diagnosisMetadata)) {
+			if (new MigrateDiagnosis().migrate(diagnosisMetadata, emrApiProps)) {
 				session.setAttribute(WebConstants.OPENMRS_MSG_ATTR, "emrapi.migrateDiagnosis.success.name");
 			} else {
 				session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "emrapi.migrateDiagnosis.migration.error.message");

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -149,6 +149,14 @@
     </globalProperty>
 
     <globalProperty>
+        <property>emrapi.diagnosisMigrationBatchSize</property>
+        <defaultValue>500</defaultValue>
+        <description>
+            Specifies the batch size to use when migrating diagnoses from the legacy diagnosis model to the new one.
+        </description>
+    </globalProperty>
+
+    <globalProperty>
         <property>emrapi.serializer.whitelist.types</property>
         <defaultValue>org.openmrs.module.emrapi.metadata.MetadataPackagesConfig,org.openmrs.module.emrapi.metadata.MetadataPackageConfig</defaultValue>
         <description></description>


### PR DESCRIPTION
Issue: https://openmrs.atlassian.net/browse/EA-216

This PR implements multithreaded batch processing for migrating EMR-API diagnoses to OpenMRS Core diagnoses;
- Added two methods to `EmrApiDao` to be able to fetch patient Ids in batches.
- Use configurable batch size (default 500) via `emrapi.diagnosisMigrationBatchSize`.
- Implement parallel processing using ExecutorService with thread pool based on CPU cores.
- 