### PR TITLE
EA-216: Improve diagnosis migration performance for large datasets

### DIFF
--- a/api/src/main/java/org/openmrs/module/emrapi/diagnosis/ObsGroupDiagnosisService.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/diagnosis/ObsGroupDiagnosisService.java
@@ -16,6 +16,7 @@ import org.openmrs.util.OpenmrsUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -26,7 +27,7 @@ import java.util.Set;
 
 public class ObsGroupDiagnosisService {
 
-    private static final Log log = LogFactory.getLog(DiagnosisService.class);
+    private static final Log log = LogFactory.getLog(ObsGroupDiagnosisService.class);
 
 	private EmrApiProperties emrApiProperties;
 

--- a/api/src/main/resources/hql/patients_diagnoses.hql
+++ b/api/src/main/resources/hql/patients_diagnoses.hql
@@ -7,4 +7,5 @@ where
     and p.patientId in(select distinct personId from Obs o
     where
         o.concept = :diagnosisSetConcept
+        and o.voided = 'false'
     )


### PR DESCRIPTION
Issue: https://openmrs.atlassian.net/browse/EA-216

This PR implement batch processing for patients - Diagnosis migration. Flush & clear the session after each batch.