### PR TITLE
EA-230: Ensure diagnosis concept mappings exist on startup and handle MissingConceptException gracefully

### DIFF
--- a/api/src/main/java/org/openmrs/module/emrapi/EmrApiActivator.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/EmrApiActivator.java
@@ -16,10 +16,16 @@ package org.openmrs.module.emrapi;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.openmrs.Concept;
+import org.openmrs.ConceptMap;
+import org.openmrs.ConceptMapType;
+import org.openmrs.ConceptName;
+import org.openmrs.ConceptReferenceTerm;
 import org.openmrs.ConceptSource;
 import org.openmrs.EncounterRole;
 import org.openmrs.EncounterType;
@@ -138,6 +144,9 @@ public class EmrApiActivator extends BaseModuleActivator implements DaemonTokenA
         metadataMappingService = Context.getService(MetadataMappingService.class);
 
         createMissingMetadataMappings();
+        ConceptService conceptService = Context.getConceptService();
+        createConceptSource(conceptService);
+        ensureDiagnosisConceptsExist(conceptService);
         createUnknownProvider();
 
         administrationService.setGlobalProperty(OpenmrsConstants.GP_VISIT_ASSIGNMENT_HANDLER, EmrApiVisitAssignmentHandler.class.getName());
@@ -363,5 +372,68 @@ public class EmrApiActivator extends BaseModuleActivator implements DaemonTokenA
     @Override
     public void setDaemonToken(DaemonToken token) {
         daemonToken = token;
+    }
+
+    /**
+ * Ensures required concepts for DiagnosisMetadata exist with correct
+ * mappings to the emrapi concept source. Required for encounter diagnosis
+ * migration to work correctly. EA-230
+ */
+void ensureDiagnosisConceptsExist(ConceptService conceptService) {
+    ConceptSource emrConceptSource = conceptService.getConceptSourceByName(EmrApiConstants.EMR_CONCEPT_SOURCE_NAME);
+    if (emrConceptSource == null) {
+        log.warn("EmrApi: concept source not found, cannot ensure diagnosis concepts exist.");
+        return;
+    }
+    ConceptMapType sameAs = conceptService.getConceptMapTypeByUuid(EmrApiConstants.SAME_AS_CONCEPT_MAP_TYPE_UUID);
+    if (sameAs == null) {
+        log.warn("EmrApi: SAME-AS concept map type not found, cannot ensure diagnosis concepts exist.");
+        return;
+    }
+    ensureConceptWithMapping(conceptService, emrConceptSource, sameAs,
+            EmrApiConstants.CONCEPT_CODE_DIAGNOSIS_CONCEPT_SET, "Diagnosis Concept Set", "ConvSet", "N/A", true);
+    ensureConceptWithMapping(conceptService, emrConceptSource, sameAs,
+            EmrApiConstants.CONCEPT_CODE_CODED_DIAGNOSIS, "Coded Diagnosis", "Misc", "Coded", false);
+    ensureConceptWithMapping(conceptService, emrConceptSource, sameAs,
+            EmrApiConstants.CONCEPT_CODE_NON_CODED_DIAGNOSIS, "Non-Coded Diagnosis", "Misc", "Text", false);
+    ensureConceptWithMapping(conceptService, emrConceptSource, sameAs,
+            EmrApiConstants.CONCEPT_CODE_DIAGNOSIS_ORDER, "Diagnosis Order", "Misc", "Coded", false);
+    ensureConceptWithMapping(conceptService, emrConceptSource, sameAs,
+            EmrApiConstants.CONCEPT_CODE_DIAGNOSIS_CERTAINTY, "Diagnosis Certainty", "Misc", "Coded", false);
+}
+
+private void ensureConceptWithMapping(ConceptService conceptService, ConceptSource source,
+        ConceptMapType mapType, String code, String name, String className, String datatypeName, boolean isSet) {
+    // If already correctly mapped, nothing to do
+    if (conceptService.getConceptByMapping(code, source.getName()) != null) {
+        return;
+    }
+    // Try to find an existing concept by name first
+    Concept concept = null;
+    List<Concept> found = conceptService.getConceptsByName(name);
+    if (found != null && !found.isEmpty()) {
+        concept = found.get(0);
+    }
+    // Create the concept if it doesn't exist at all
+    if (concept == null) {
+        concept = new Concept();
+        concept.setConceptClass(conceptService.getConceptClassByName(className));
+        concept.setDatatype(conceptService.getConceptDatatypeByName(datatypeName));
+        concept.setSet(isSet);
+        ConceptName conceptName = new ConceptName(name, Locale.ENGLISH);
+        concept.addName(conceptName);
+        concept = conceptService.saveConcept(concept);
+        log.info("EmrApi: created missing concept '" + name + "'");
+    }
+    // Ensure the reference term exists in the source
+    ConceptReferenceTerm term = conceptService.getConceptReferenceTermByCode(code, source);
+    if (term == null) {
+        term = new ConceptReferenceTerm(source, code, null);
+        term = conceptService.saveConceptReferenceTerm(term);
+    }
+    // Add the mapping to the concept
+    concept.addConceptMapping(new ConceptMap(term, mapType));
+    conceptService.saveConcept(concept);
+    log.info("EmrApi: added mapping '" + source.getName() + ":" + code + "' to concept '" + name + "'");
     }
 }

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -17,6 +17,7 @@ emrapi.migrateDiagnosis.migration.error.message=Migration failed, you either alr
 emrapi.migrateDiagnosis.operation.warning.message=Migration of Encounter Diagnosis Operation is irreversible and made only ONCE, are sure you want to continue?  
 emrapi.migrateDiagnosis.verify.operation.name=Verify Operation
 emrapi.migrateDiagnosis.migration.unsupportedPlatformVersionError.message=Unsupported Operation, this feature is only supported by platform 2.2.0 or later versions.
+emrapi.migrateDiagnosis.missingConcept.error.message=Migration failed: Required diagnosis concept mappings are not configured. Please ensure the emrapi module has been fully started and try again.
 
 # Shared message codes for account management
 

--- a/omod/src/main/java/org/openmrs/module/emrapi/web/controller/MigrateDiagnosisController.java
+++ b/omod/src/main/java/org/openmrs/module/emrapi/web/controller/MigrateDiagnosisController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import org.openmrs.module.emrapi.diagnosis.MigrateDiagnosis;
+import org.openmrs.module.emrapi.descriptor.MissingConceptException;
 
 @Controller
 public class MigrateDiagnosisController {
@@ -29,7 +30,13 @@ public class MigrateDiagnosisController {
 	
 	@RequestMapping(value = "module/emrapi/migrateEncounterDiagnosis.form", method = RequestMethod.GET)
 	public String doEncounterDiagnosisMigration(HttpSession session, HttpServletRequest request) {
-		DiagnosisMetadata diagnosisMetadata = emrApiProps.getDiagnosisMetadata();
+		DiagnosisMetadata diagnosisMetadata;
+			try {
+				diagnosisMetadata = emrApiProps.getDiagnosisMetadata();
+			} catch (MissingConceptException e) {
+				session.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "emrapi.migrateDiagnosis.missingConcept.error.message");
+				return "redirect:encounterDiagnosisMigrationDashboard.form";
+			}
 		if (ModuleUtil.compareVersion(OpenmrsConstants.OPENMRS_VERSION, "2.2.0") >= 0) {
 			if (new MigrateDiagnosis().migrate(diagnosisMetadata)) {
 				session.setAttribute(WebConstants.OPENMRS_MSG_ATTR, "emrapi.migrateDiagnosis.success.name");


### PR DESCRIPTION
In EmrApiActivator.java,
called createConceptSource() from started() so the org.openmrs.module.emrapi concept source is always created on module startup if it doesn't already exist.
Added ensureDiagnosisConceptsExist() — a new method called from started() that checks whether all required DiagnosisMetadata concepts exist in the database with their correct mappings. If any are missing, it creates both the concept and its mapping automatically. The required concepts are:

Diagnosis Concept Set
Coded Diagnosis
Non-Coded Diagnosis
Diagnosis Order
Diagnosis Certainty

Also added ensureConceptWithMapping() — a private helper method that handles creation of a single concept and its reference term mapping in a safe, idempotent way (skips silently if the mapping already exists).

In MigrateDiagnosisController.java,
added import org.openmrs.module.emrapi.descriptor.MissingConceptException
Wrapped emrApiProps.getDiagnosisMetadata() in a try/catch block for MissingConceptException. If the exception is thrown, the user is now redirected back to the dashboard with a clear, readable error message instead of a raw Java exception page.

In messages.properties
Added the missing message key emrapi.migrateDiagnosis.missingConcept.error.message with a descriptive error message that guides the user on what went wrong.

**Related.**
https://openmrs.atlassian.net/browse/EA-230
