### PR TITLE
Make body site field nullable in procedures

### DIFF
--- a/api/src/main/java/org/openmrs/module/emrapi/procedure/Procedure.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/procedure/Procedure.java
@@ -62,7 +62,7 @@ public class Procedure extends BaseFormRecordableOpenmrsData {
 	private String procedureNonCoded;
 	
 	@ManyToOne
-	@JoinColumn(name = "body_site_coded", nullable = false)
+	@JoinColumn(name = "body_site_coded", nullable = true)
 	private Concept bodySite;
 	
 	@Column(name = "start_date_time", nullable = false)

--- a/api/src/main/java/org/openmrs/module/emrapi/procedure/ProcedureValidator.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/procedure/ProcedureValidator.java
@@ -49,9 +49,6 @@ public class ProcedureValidator implements Validator {
 					errors.reject("Procedure.error.endDateTimeBeforeStartDateTime");
 				}
 			}
-			if (procedure.getBodySite() == null) {
-				errors.reject("Procedure.error.bodySiteRequired");
-			}
 			if (procedure.getEstimatedStartDate() == null && procedure.getStartDateTime() == null) {
 				errors.reject("Procedure.error.startDateTimeRequired");
 			}

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -259,4 +259,16 @@
             <column name="start_date_time"/>
         </createIndex>
     </changeSet>
+
+    <changeSet id="emrapi-202605061002" author="openmrs">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="emrapi_procedure" columnName="body_site_coded"/>
+        </preConditions>
+        <comment>Make body_site_coded field nullable in emrapi_procedure table</comment>
+
+        <dropNotNullConstraint
+                tableName="emrapi_procedure"
+                columnName="body_site_coded"
+                columnDataType="int"/>
+    </changeSet>
 </databaseChangeLog>

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -102,7 +102,6 @@ ProcedureValidator.onlySupportsProcedure=Validator only supports Procedure objec
 Procedure.error.patientRequired=Patient is required
 Procedure.error.procedureRequired=Either a coded or non-coded procedure must be provided
 Procedure.error.procedureCodedAndNonCodedMutuallyExclusive=Coded and non-coded procedure are mutually exclusive
-Procedure.error.bodySiteRequired=Body site is required
 Procedure.error.startDateTimeRequired=Either start date/time or estimated start date must be provided
 Procedure.error.startDateTimeAndEstimatedDateMutuallyExclusiveForNewProcedures=Start date/time and estimated start date are mutually exclusive for new procedures
 Procedure.error.endDateTimeBeforeStartDateTime=End date/time cannot be before start date/time

--- a/api/src/test/java/org/openmrs/module/emrapi/procedure/ProcedureValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/emrapi/procedure/ProcedureValidatorTest.java
@@ -105,13 +105,6 @@ class ProcedureValidatorTest {
 	}
 	
 	@Test
-	void validate_shouldRejectWhenBodySiteIsNull() {
-		procedure.setBodySite(null);
-		validator.validate(procedure, errors);
-		assertTrue(hasErrorCode("Procedure.error.bodySiteRequired"));
-	}
-	
-	@Test
 	void validate_shouldRejectWhenBothStartDateTimeAndEstimatedStartDateAreNull() {
 		procedure.setStartDateTime(null);
 		procedure.setEstimatedStartDate(null);


### PR DESCRIPTION
It's not always guaranteed that a procedure will have an associated body site. This PR adds a new migration to drop the NOT NULL constraint on the body_site_coded column, allowing procedures to be recorded without specifying a body site.

ex:

- A general counseling procedure
- Blood transfusion
- Physiotherapy session