### PR TITLE
Qualify StringToProviderRoleConverter bean name to avoid clash with providermanagement

### DIFF
--- a/api/src/main/java/org/openmrs/module/emrapi/account/StringToProviderRoleConverter.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/account/StringToProviderRoleConverter.java
@@ -18,9 +18,9 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
 /**
- * Converts String to ProviderRole. Ideally this would be in core.
+ * Converts String to ProviderRole. Ideally, this would be in core.
  */
-@Component
+@Component("emrapiStringToProviderRoleConverter")
 public class StringToProviderRoleConverter implements Converter<String, ProviderRole> {
 	
 	@Autowired


### PR DESCRIPTION
`org.openmrs.module.emrapi.account.StringToProviderRoleConverter` and [org.openmrs.module.providermanagement.converter.StringToProviderRoleConverter](https://github.com/openmrs/openmrs-module-providermanagement/blob/647643dc76047ead89d5a7a9fedfe05b5b87f5ca/api/src/main/java/org/openmrs/module/providermanagement/converter/StringToProviderRoleConverter.java#L27) are both annotated with `@Component` and have the same simple class name. Spring's default `@Component` naming generates the same bean ID for both.

We need this for: https://github.com/mekomsolutions/openmrs-module-initializer/pull/323#pullrequestreview-4314298775