### PR TITLE
EA-233: Create controller to return dose forms, dose form groupos and…

### DIFF
--- a/api/src/main/java/org/openmrs/module/emrapi/EmrApiConstants.java
+++ b/api/src/main/java/org/openmrs/module/emrapi/EmrApiConstants.java
@@ -116,6 +116,8 @@ public class EmrApiConstants {
 	
 	public static final String NARROWER_THAN_CONCEPT_MAP_TYPE_UUID = "43ac5109-7d8c-11e1-909d-c80aa9edcf4e";
 	
+	public static final String ROUTE_OF_ADMINISTRATION_CONCEPT_MAP_TYPE_UUID = "8ee5b13d-7d8e-11e1-909d-c80aa9edcf4e";
+	
 	public static final String EMR_CONCEPT_SOURCE_NAME = "org.openmrs.module.emrapi";
 	
 	public static final String EMR_CONCEPT_SOURCE_DESCRIPTION = "Source used to tag concepts used in the EMR API module";

--- a/omod/src/main/java/org/openmrs/module/emrapi/rest/converter/SimpleBeanConverter.java
+++ b/omod/src/main/java/org/openmrs/module/emrapi/rest/converter/SimpleBeanConverter.java
@@ -19,6 +19,9 @@ import org.openmrs.module.emrapi.diagnosis.DiagnosisMetadata;
 import org.openmrs.module.emrapi.disposition.Disposition;
 import org.openmrs.module.emrapi.disposition.DispositionDescriptor;
 import org.openmrs.module.emrapi.disposition.DispositionObs;
+import org.openmrs.module.emrapi.web.controller.types.DoseFormGroupRoutes;
+import org.openmrs.module.emrapi.web.controller.types.DoseFormGroupsResponse;
+import org.openmrs.module.emrapi.web.controller.types.DoseFormMembership;
 import org.openmrs.module.webservices.rest.SimpleObject;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.representation.CustomRepresentation;
@@ -32,7 +35,8 @@ import java.beans.PropertyDescriptor;
 import java.util.Map;
 
 @Handler(supports = { EmrApiProperties.class, DiagnosisMetadata.class, Disposition.class, DispositionObs.class,
-        DispositionDescriptor.class, Diagnosis.class, }, order = 0)
+        DispositionDescriptor.class, Diagnosis.class, DoseFormGroupsResponse.class, DoseFormMembership.class,
+        DoseFormGroupRoutes.class, }, order = 0)
 public class SimpleBeanConverter<T> implements Converter<T> {
 	
 	private final Log log = LogFactory.getLog(getClass());

--- a/omod/src/main/java/org/openmrs/module/emrapi/web/controller/DoseFormGroupController.java
+++ b/omod/src/main/java/org/openmrs/module/emrapi/web/controller/DoseFormGroupController.java
@@ -1,0 +1,139 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.emrapi.web.controller;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.openmrs.Concept;
+import org.openmrs.ConceptClass;
+import org.openmrs.ConceptMap;
+import org.openmrs.ConceptMapType;
+import org.openmrs.ConceptReferenceTerm;
+import org.openmrs.api.APIException;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.emrapi.EmrApiConstants;
+import org.openmrs.module.emrapi.web.controller.types.DoseFormGroupRoutes;
+import org.openmrs.module.emrapi.web.controller.types.DoseFormGroupsResponse;
+import org.openmrs.module.emrapi.web.controller.types.DoseFormMembership;
+import org.openmrs.module.webservices.rest.web.ConversionUtil;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestUtil;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequestMapping(value = "/rest/**/emrapi/doseFormGroups")
+public class DoseFormGroupController {
+
+	private static final String DRUG_FORM_CONCEPT_CLASS_NAME = "Drug form";
+
+	private static final String DOSE_FORM_GROUP_CONCEPT_CLASS_NAME = "Dose Form Group";
+
+	/**
+	 * Returns a {@link DoseFormGroupsResponse}, which contains mappings for: - dose form to its dose
+	 * form group, which is null for a dose form that belongs to no group - dose form group to its
+	 * routes of administration
+	 *
+	 * @param request the current request, used to resolve the requested representation
+	 * @param response the current response
+	 * @return the dose forms and dose form groups, converted to the requested representation
+	 * @throws APIException if a dose form belongs to more than one dose form group
+	 */
+	@RequestMapping(method = RequestMethod.GET)
+	@ResponseBody
+	public Object getDoseFormGroups(HttpServletRequest request, HttpServletResponse response) {
+		RequestContext context = RestUtil.getRequestContext(request, response, Representation.DEFAULT);
+
+		ConceptService cs = Context.getConceptService();
+		ConceptClass doseFormGroupClass = cs.getConceptClassByName(DOSE_FORM_GROUP_CONCEPT_CLASS_NAME);
+		List<Concept> doseFormGroups = cs.getConceptsByClass(doseFormGroupClass);
+
+		List<DoseFormGroupRoutes> doseFormGroupRoutes = new ArrayList<>();
+		// A dose form may belong to at most one dose form group; the concept set membership does not
+		// enforce this, so track the claiming group and fail if a second group claims the same form
+		Map<String, Concept> claimingGroupByDoseFormUuid = new HashMap<>();
+
+		for (Concept doseFormGroup : doseFormGroups) {
+			for (Concept doseForm : doseFormGroup.getSetMembers()) {
+				Concept claimingGroup = claimingGroupByDoseFormUuid.put(doseForm.getUuid(), doseFormGroup);
+				if (claimingGroup != null) {
+					throw new APIException("Dose form '" + displayOf(doseForm) + "' (" + doseForm.getUuid()
+					        + ") belongs to more than one dose form group: '" + displayOf(claimingGroup) + "' and '"
+					        + displayOf(doseFormGroup) + "'. A dose form may belong to at most one group.");
+				}
+			}
+
+			doseFormGroupRoutes.add(new DoseFormGroupRoutes(doseFormGroup, getRoutesOfAdministration(cs, doseFormGroup)));
+		}
+
+		// Every dose form is reported, whether or not a group claims it. The dose forms are enumerated
+		// from their concept class rather than from group membership so that a dose form belonging to no
+		// group is still returned, with a null dose form group.
+		ConceptClass doseFormClass = cs.getConceptClassByName(DRUG_FORM_CONCEPT_CLASS_NAME);
+		List<DoseFormMembership> doseFormMemberships = new ArrayList<>();
+		for (Concept doseForm : cs.getConceptsByClass(doseFormClass)) {
+			doseFormMemberships.add(new DoseFormMembership(doseForm, claimingGroupByDoseFormUuid.get(doseForm.getUuid())));
+		}
+
+		DoseFormGroupsResponse result = new DoseFormGroupsResponse(doseFormMemberships, doseFormGroupRoutes);
+		return ConversionUtil.convertToRepresentation(result, context.getRepresentation());
+	}
+
+	/**
+	 * Returns the routes of administration mapped to the given dose form groupt add.
+	 */
+	private List<Concept> getRoutesOfAdministration(ConceptService cs, Concept doseFormGroup) {
+		List<Concept> routes = new ArrayList<>();
+		for (ConceptMap conceptMap : doseFormGroup.getConceptMappings()) {
+			ConceptMapType mapType = conceptMap.getConceptMapType();
+			if (EmrApiConstants.ROUTE_OF_ADMINISTRATION_CONCEPT_MAP_TYPE_UUID.equals(mapType.getUuid())) {
+				ConceptReferenceTerm term = conceptMap.getConceptReferenceTerm();
+				Concept route = getConceptBySameAsMapping(cs, term);
+				if (route != null) {
+					routes.add(route);
+				}
+			}
+		}
+		return routes;
+	}
+
+	/**
+	 * Retrieves a concept by ConceptReferenceTerm (conceptSource + code) with SAME-AS mapping. This
+	 * function is similar to ConceptService.getConceptByMapping(). However, that function does not
+	 * check for the mapping type (we need the SAME-AS mapping), and throws an exception if the
+	 * ConceptReferenceTerm has multiple mappings, even if they are of different mapping types.
+	 */
+	private Concept getConceptBySameAsMapping(ConceptService cs, ConceptReferenceTerm term) {
+		List<Concept> candidates = cs.getConceptsByMapping(term.getCode(), term.getConceptSource().getName(), false);
+		for (Concept candidate : candidates) {
+			for (ConceptMap candidateMap : candidate.getConceptMappings()) {
+				if (EmrApiConstants.SAME_AS_CONCEPT_MAP_TYPE_UUID.equals(candidateMap.getConceptMapType().getUuid())
+				        && term.getUuid().equals(candidateMap.getConceptReferenceTerm().getUuid())) {
+					return candidate;
+				}
+			}
+		}
+		return null;
+	}
+
+	private String displayOf(Concept concept) {
+		return concept.getName() == null ? null : concept.getName().getName();
+	}
+}

--- a/omod/src/main/java/org/openmrs/module/emrapi/web/controller/types/DoseFormGroupRoutes.java
+++ b/omod/src/main/java/org/openmrs/module/emrapi/web/controller/types/DoseFormGroupRoutes.java
@@ -1,0 +1,30 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.emrapi.web.controller.types;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.openmrs.Concept;
+
+/**
+ * A dose form group and its routes of administration.
+ * <p>
+ * Converted to a representation by SimpleBeanConverter, which is registered for this class.
+ */
+@Data
+@AllArgsConstructor
+public class DoseFormGroupRoutes {
+	
+	private Concept doseFormGroup;
+	
+	private List<Concept> routes;
+}

--- a/omod/src/main/java/org/openmrs/module/emrapi/web/controller/types/DoseFormGroupsResponse.java
+++ b/omod/src/main/java/org/openmrs/module/emrapi/web/controller/types/DoseFormGroupsResponse.java
@@ -1,0 +1,32 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.emrapi.web.controller.types;
+
+import java.util.List;
+
+import org.openmrs.module.emrapi.web.controller.DoseFormGroupController;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * The response of {@link DoseFormGroupController}: which dose form group each dose form belongs to,
+ * and which routes of administration each dose form group has.
+ * <p>
+ * Converted to a representation by SimpleBeanConverter, which is registered for this class.
+ */
+@Data
+@AllArgsConstructor
+public class DoseFormGroupsResponse {
+	
+	private List<DoseFormMembership> doseForms;
+	
+	private List<DoseFormGroupRoutes> doseFormGroups;
+}

--- a/omod/src/main/java/org/openmrs/module/emrapi/web/controller/types/DoseFormMembership.java
+++ b/omod/src/main/java/org/openmrs/module/emrapi/web/controller/types/DoseFormMembership.java
@@ -1,0 +1,31 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.emrapi.web.controller.types;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.openmrs.Concept;
+
+/**
+ * A dose form and the dose form group it belongs to, if any.
+ * <p>
+ * Converted to a representation by SimpleBeanConverter, which is registered for this class.
+ */
+@Data
+@AllArgsConstructor
+public class DoseFormMembership {
+	
+	private Concept doseForm;
+	
+	/**
+	 * Null when no dose form group claims this dose form. A dose form belongs to at most one group.
+	 */
+	private Concept doseFormGroup;
+}

--- a/omod/src/test/java/org/openmrs/module/emrapi/web/controller/DoseFormGroupControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/emrapi/web/controller/DoseFormGroupControllerTest.java
@@ -1,0 +1,192 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.emrapi.web.controller;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.api.APIException;
+import org.openmrs.web.test.BaseModuleWebContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class DoseFormGroupControllerTest extends BaseModuleWebContextSensitiveTest {
+	
+	private static final String TABLET_UUID = "c3e6a0d4-5b8f-4c1e-d7a9-0f4b2c8e3d15";
+	
+	@Autowired
+	DoseFormGroupController controller;
+	
+	@Before
+	public void setUp() throws Exception {
+		executeDataSet("doseFormGroupDataset.xml");
+	}
+	
+	/**
+	 * Pins the response contract: the top-level keys, the nesting under each, and the dose form to dose
+	 * form group mapping itself. A dose form belongs to at most one group, so "Ointment", which belongs
+	 * to none, is still reported, with a null dose form group.
+	 */
+	@Test
+	public void shouldReturnEachDoseFormMappedToItsDoseFormGroup() throws Exception {
+		Map<String, List<Map<String, Object>>> response = getDoseFormGroups();
+		
+		assertNotNull("response should contain a doseForms entry", response.get("doseForms"));
+		assertNotNull("response should contain a doseFormGroups entry", response.get("doseFormGroups"));
+		
+		Map<String, String> groupByDoseForm = new HashMap<String, String>();
+		for (Map<String, Object> entry : response.get("doseForms")) {
+			groupByDoseForm.put(displayOf(entry.get("doseForm")), displayOf(entry.get("doseFormGroup")));
+		}
+		
+		assertEquals("Oral Solid", groupByDoseForm.get("Tablet"));
+		assertEquals("Oral Solid", groupByDoseForm.get("Capsule"));
+		assertEquals("Injectable", groupByDoseForm.get("Solution for Injection"));
+		assertTrue("a dose form in no group should still be reported", groupByDoseForm.containsKey("Ointment"));
+		assertNull("a dose form in no group should have a null dose form group", groupByDoseForm.get("Ointment"));
+		assertEquals(4, groupByDoseForm.size());
+	}
+	
+	/**
+	 * A dose form group's routes come from its route-of-administration mappings, resolved to concepts
+	 * via a SAME-AS mapping on the same reference term. "Oral Solid" points at a term that concept
+	 * "Oral" claims that way, so the route resolves. "Injectable" points at a term no concept claims,
+	 * and the controller drops it silently rather than failing the whole request.
+	 */
+	@Test
+	public void shouldReturnRoutesResolvedBySameAsMappingAndDropUnresolvableOnes() throws Exception {
+		Map<String, List<Map<String, Object>>> response = getDoseFormGroups();
+		
+		List<Map<String, Object>> doseFormGroups = response.get("doseFormGroups");
+		assertEquals(2, doseFormGroups.size());
+		
+		Map<String, List<String>> routesByGroup = new HashMap<String, List<String>>();
+		for (Map<String, Object> entry : doseFormGroups) {
+			List<String> routes = new ArrayList<String>();
+			for (Object route : (List<?>) entry.get("routes")) {
+				routes.add(displayOf(route));
+			}
+			routesByGroup.put(displayOf(entry.get("doseFormGroup")), routes);
+		}
+		
+		assertEquals(1, routesByGroup.get("Oral Solid").size());
+		assertEquals("Oral", routesByGroup.get("Oral Solid").get(0));
+		
+		assertTrue("a route with no SAME-AS mapped concept should be omitted", routesByGroup.get("Injectable").isEmpty());
+	}
+	
+	/**
+	 * The requested representation has to reach the nested Concepts. It only does so because the
+	 * response is a bean with a registered Converter: ConversionUtil converts the values of a Map with
+	 * a hardcoded Representation.REF, so back when this endpoint returned a SimpleObject every Concept
+	 * came back as a REF no matter what was asked for.
+	 */
+	@Test
+	public void shouldReturnConceptsInTheRequestedRepresentation() throws Exception {
+		Set<String> refProperties = new HashSet<String>(Arrays.asList("uuid", "display", "links"));
+		
+		Map<String, Object> asRef = firstDoseForm(representation("ref"));
+		assertEquals(refProperties, asRef.keySet());
+		
+		Map<String, Object> asFull = firstDoseForm(representation("full"));
+		assertTrue("expected more than a REF, got " + asFull.keySet(),
+		    asFull.keySet().containsAll(Arrays.asList("uuid", "display", "datatype", "conceptClass")));
+		
+		// the default is what clients that do not ask for a representation actually receive
+		Map<String, Object> asDefault = firstDoseForm(new MockHttpServletRequest());
+		assertTrue("expected more than a REF, got " + asDefault.keySet(),
+		    asDefault.keySet().containsAll(Arrays.asList("uuid", "display", "datatype", "conceptClass")));
+		
+		// A Concept's default representation includes setMembers, so by default every dose form group
+		// also carries a nested list of its own dose forms, i.e. the doseForms list is repeated inside
+		// doseFormGroups. Pinned so that trimming the default payload is a deliberate change.
+		Map<String, Object> group = asConcept(getDoseFormGroups().get("doseFormGroups").get(0).get("doseFormGroup"));
+		assertNotNull("dose form groups carry their set members by default", group.get("setMembers"));
+	}
+	
+	/**
+	 * A custom representation is handled by a different branch of SimpleBeanConverter, which builds its
+	 * description from the request rather than by introspecting the bean.
+	 */
+	@Test
+	public void shouldSupportACustomRepresentation() throws Exception {
+		Map<String, List<Map<String, Object>>> response = getDoseFormGroups(representation("custom:(doseForms)"));
+		
+		assertNotNull("doseForms was asked for", response.get("doseForms"));
+		assertEquals("only doseForms was asked for", 1, response.keySet().size());
+	}
+	
+	@Test
+	public void shouldFailWhenADoseFormBelongsToMoreThanOneDoseFormGroup() throws Exception {
+		executeDataSet("doseFormGroupDuplicateDataset.xml");
+		
+		try {
+			getDoseFormGroups();
+			fail("expected an APIException because Tablet belongs to two dose form groups");
+		}
+		catch (APIException e) {
+			// the group that gets to claim the form first depends on the order concepts come back in,
+			// so assert on the parts of the message that do not depend on it
+			assertTrue(e.getMessage(), e.getMessage().contains("Tablet"));
+			assertTrue(e.getMessage(), e.getMessage().contains(TABLET_UUID));
+			assertTrue(e.getMessage(), e.getMessage().contains("belongs to more than one dose form group"));
+			assertTrue(e.getMessage(), e.getMessage().contains("Oral Solid"));
+			assertTrue(e.getMessage(), e.getMessage().contains("Oral Liquid"));
+		}
+	}
+	
+	private MockHttpServletRequest representation(String v) {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setParameter("v", v);
+		return request;
+	}
+	
+	private Map<String, Object> firstDoseForm(MockHttpServletRequest request) {
+		return asConcept(getDoseFormGroups(request).get("doseForms").get(0).get("doseForm"));
+	}
+	
+	private Map<String, List<Map<String, Object>>> getDoseFormGroups() {
+		return getDoseFormGroups(new MockHttpServletRequest());
+	}
+	
+	@SuppressWarnings("unchecked")
+	private Map<String, List<Map<String, Object>>> getDoseFormGroups(MockHttpServletRequest request) {
+		return (Map<String, List<Map<String, Object>>>) controller.getDoseFormGroups(request, new MockHttpServletResponse());
+	}
+	
+	/**
+	 * Each Concept in the response has been converted to a representation, i.e. a map of properties.
+	 */
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> asConcept(Object convertedConcept) {
+		return (Map<String, Object>) convertedConcept;
+	}
+	
+	/**
+	 * Null for the dose form group of a dose form that belongs to no group.
+	 */
+	private String displayOf(Object convertedConcept) {
+		return convertedConcept == null ? null : (String) asConcept(convertedConcept).get("display");
+	}
+}

--- a/omod/src/test/resources/doseFormGroupDataset.xml
+++ b/omod/src/test/resources/doseFormGroupDataset.xml
@@ -1,0 +1,77 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<!--
+    Metadata for DoseFormGroupControllerTest.
+
+    Two dose form groups, each a concept set of dose forms, each mapped to a route of
+    administration reference term:
+
+      Oral Solid (5001) -> Tablet (5011), Capsule (5012)
+        route term ROUTE-ORAL (5031), which concept Oral (5021) claims via a SAME-AS mapping
+      Injectable (5002) -> Solution for Injection (5013)
+        route term ROUTE-UNRESOLVED (5032), which no concept claims via SAME-AS
+
+    Ointment (5014) is a dose form belonging to no group at all, which is allowed: it is still
+    returned, with a null dose form group.
+
+    Note that term 5031 carries mappings of two different types (route-of-administration from
+    the group, SAME-AS from the route concept). That is deliberate: it is the case
+    ConceptService.getConceptByMapping() rejects, and the reason the controller resolves routes
+    itself.
+
+    The "same-as" concept map type (id 2) and the "Misc" (11) concept class come from the core
+    standardTestDataset; the route-of-administration map type and the "Drug form" and "Dose Form
+    Group" concept classes do not, so they are created here. The dose form concept class really is
+    named "Drug form" in the dictionary, which is why that name is used here.
+-->
+<dataset>
+
+    <concept_class concept_class_id="50" name="Dose Form Group" description="Groups dose forms sharing routes of administration" creator="1" date_created="2004-08-12 00:00:00.0" retired="false" uuid="0f7b3d2e-6f1a-4c9b-9f4d-2a1c6b8e5d70"/>
+    <concept_class concept_class_id="51" name="Drug form" description="The form a drug is dosed in" creator="1" date_created="2004-08-12 00:00:00.0" retired="false" uuid="1e8c4d3f-7a2b-4d0c-8e5f-3b2c7d9a6e81"/>
+
+    <concept_map_type concept_map_type_id="20" name="route of administration" description="Maps a dose form group to a route of administration" is_hidden="0" retired="0" creator="1" date_created="2004-08-12 00:00:00.0" uuid="8ee5b13d-7d8e-11e1-909d-c80aa9edcf4e"/>
+
+    <concept_reference_source concept_source_id="50" name="Dose Form Test Source" description="Source used only by DoseFormGroupControllerTest" hl7_code="DFTS" creator="1" date_created="2004-08-12 00:00:00.0" retired="false" uuid="5f2c1a90-4d7e-4b3c-8a6f-1b9d0e3c7a41"/>
+
+    <!-- dose form groups -->
+    <concept concept_id="5001" retired="false" datatype_id="4" class_id="50" is_set="true" creator="1" date_created="2004-08-12 00:00:00.0" uuid="a1c4e8b2-3f6d-4a9c-b5e7-8d2f0a6c1b93"/>
+    <concept concept_id="5002" retired="false" datatype_id="4" class_id="50" is_set="true" creator="1" date_created="2004-08-12 00:00:00.0" uuid="b2d5f9c3-4a7e-4b0d-c6f8-9e3a1b7d2c04"/>
+    <!-- dose forms -->
+    <concept concept_id="5011" retired="false" datatype_id="4" class_id="51" is_set="false" creator="1" date_created="2004-08-12 00:00:00.0" uuid="c3e6a0d4-5b8f-4c1e-d7a9-0f4b2c8e3d15"/>
+    <concept concept_id="5012" retired="false" datatype_id="4" class_id="51" is_set="false" creator="1" date_created="2004-08-12 00:00:00.0" uuid="d4f7b1e5-6c9a-4d2f-e8b0-1a5c3d9f4e26"/>
+    <concept concept_id="5013" retired="false" datatype_id="4" class_id="51" is_set="false" creator="1" date_created="2004-08-12 00:00:00.0" uuid="e5a8c2f6-7d0b-4e3a-f9c1-2b6d4e0a5f37"/>
+    <!-- Ointment deliberately belongs to no dose form group, which is allowed -->
+    <concept concept_id="5014" retired="false" datatype_id="4" class_id="51" is_set="false" creator="1" date_created="2004-08-12 00:00:00.0" uuid="a6b9c2d5-8e1f-4a3b-c7d0-3e5f1a8b6c48"/>
+    <!-- route of administration -->
+    <concept concept_id="5021" retired="false" datatype_id="4" class_id="11" is_set="false" creator="1" date_created="2004-08-12 00:00:00.0" uuid="f6b9d3a7-8e1c-4f4b-a0d2-3c7e5f1b6a48"/>
+
+    <concept_name concept_name_id="5001" concept_id="5001" name="Oral Solid" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="a1c4e8b2-3f6d-4a9c-b5e7-8d2f0a6c1b01"/>
+    <concept_name concept_name_id="5002" concept_id="5002" name="Injectable" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="b2d5f9c3-4a7e-4b0d-c6f8-9e3a1b7d2c02"/>
+    <concept_name concept_name_id="5011" concept_id="5011" name="Tablet" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="c3e6a0d4-5b8f-4c1e-d7a9-0f4b2c8e3d11"/>
+    <concept_name concept_name_id="5012" concept_id="5012" name="Capsule" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="d4f7b1e5-6c9a-4d2f-e8b0-1a5c3d9f4e12"/>
+    <concept_name concept_name_id="5013" concept_id="5013" name="Solution for Injection" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="e5a8c2f6-7d0b-4e3a-f9c1-2b6d4e0a5f13"/>
+    <concept_name concept_name_id="5014" concept_id="5014" name="Ointment" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="a6b9c2d5-8e1f-4a3b-c7d0-3e5f1a8b6c14"/>
+    <concept_name concept_name_id="5021" concept_id="5021" name="Oral" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="f6b9d3a7-8e1c-4f4b-a0d2-3c7e5f1b6a21"/>
+
+    <concept_set concept_set_id="5101" concept_id="5011" concept_set="5001" creator="1" date_created="2004-08-12 00:00:00.0" sort_weight="1" uuid="11c4e8b2-3f6d-4a9c-b5e7-8d2f0a6c1101"/>
+    <concept_set concept_set_id="5102" concept_id="5012" concept_set="5001" creator="1" date_created="2004-08-12 00:00:00.0" sort_weight="2" uuid="22d5f9c3-4a7e-4b0d-c6f8-9e3a1b7d2102"/>
+    <concept_set concept_set_id="5103" concept_id="5013" concept_set="5002" creator="1" date_created="2004-08-12 00:00:00.0" sort_weight="1" uuid="33e6a0d4-5b8f-4c1e-d7a9-0f4b2c8e3103"/>
+
+    <concept_reference_term concept_reference_term_id="5031" concept_source_id="50" code="ROUTE-ORAL" name="Oral route" creator="1" date_created="2004-08-12 00:00:00.0" retired="false" uuid="44f7b1e5-6c9a-4d2f-e8b0-1a5c3d9f4131"/>
+    <concept_reference_term concept_reference_term_id="5032" concept_source_id="50" code="ROUTE-UNRESOLVED" name="Route with no matching concept" creator="1" date_created="2004-08-12 00:00:00.0" retired="false" uuid="55a8c2f6-7d0b-4e3a-f9c1-2b6d4e0a5132"/>
+
+    <concept_reference_map concept_map_id="5041" concept_id="5001" concept_reference_term_id="5031" concept_map_type_id="20" creator="1" date_created="2004-08-12 00:00:00.0" uuid="66b9d3a7-8e1c-4f4b-a0d2-3c7e5f1b6141"/>
+    <concept_reference_map concept_map_id="5042" concept_id="5002" concept_reference_term_id="5032" concept_map_type_id="20" creator="1" date_created="2004-08-12 00:00:00.0" uuid="77c0e4b8-9f2d-4a5c-b1e3-4d8f6a2c7142"/>
+    <concept_reference_map concept_map_id="5043" concept_id="5021" concept_reference_term_id="5031" concept_map_type_id="2" creator="1" date_created="2004-08-12 00:00:00.0" uuid="88d1f5c9-0a3e-4b6d-c2f4-5e9a7b3d8143"/>
+
+</dataset>

--- a/omod/src/test/resources/doseFormGroupDuplicateDataset.xml
+++ b/omod/src/test/resources/doseFormGroupDuplicateDataset.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<!--
+    Loaded on top of doseFormGroupDataset.xml to create the illegal state the controller must
+    reject: a third dose form group, Oral Liquid (5003), that also claims Tablet (5011) as a set
+    member even though Oral Solid (5001) already does.
+-->
+<dataset>
+
+    <concept concept_id="5003" retired="false" datatype_id="4" class_id="50" is_set="true" creator="1" date_created="2004-08-12 00:00:00.0" uuid="c3e6a0d4-5b8f-4c1e-d7a9-0f4b2c8e3d03"/>
+
+    <concept_name concept_name_id="5003" concept_id="5003" name="Oral Liquid" locale="en" creator="1" date_created="2004-08-12 00:00:00.0" concept_name_type="FULLY_SPECIFIED" locale_preferred="1" voided="false" uuid="c3e6a0d4-5b8f-4c1e-d7a9-0f4b2c8e3003"/>
+
+    <concept_set concept_set_id="5104" concept_id="5011" concept_set="5003" creator="1" date_created="2004-08-12 00:00:00.0" sort_weight="1" uuid="44f7b1e5-6c9a-4d2f-e8b0-1a5c3d9f4104"/>
+
+</dataset>


### PR DESCRIPTION
… routes of administration

See: https://openmrs.atlassian.net/browse/EA-233 and [talk thread](https://talk.openmrs.org/t/proposal-for-linking-dosage-forms-to-routes-of-administration/49252).

Now that we have the relations mappings between dose form, dose form groups and routes of administration in CIEL, the PR implements a controller to return those relationships.

Tested by going to the route (`/openmrs/ws/rest/v1/emrapi/doseFormGroups`) and also by adding different representations (`?v=custom:(doseForms:(doseForm:ref,doseFormGroup:ref)`).

Note:
- I can't find a function in `ConceptService` to return a concept by reference term (`CIEL:123`) AND mapping type (`SAME-AS`), and had to make my own `getConceptBySameAsMapping()` function. Calling `ConceptService.getConceptByMapping(term)` fails because, for some dose form groups, we have multiple mappings for the same term ("SAME-AS" and "Route of administration")
- Other than the representation param (`?v=`), the controller takes no input. Not implemented, but we can technically speed up this controller via caching,
- We use "drug form" / "dose form" (and "drug form group" / "dose form group") somewhat interchangeably. I defaulted to "dose" throughout this PR, but don't have a strong preference.